### PR TITLE
Kubernetes fixes & cleanup

### DIFF
--- a/conf/kvs-config.yml
+++ b/conf/kvs-config.yml
@@ -17,7 +17,8 @@ server:
   routing: 
       - 127.0.0.1
   seed_ip: 127.0.0.1
-  ip: 127.0.0.1
+  public_ip: 127.0.0.1
+  private_ip: 127.0.0.1
 ebs: ./
 threads:
   memory: 4

--- a/dockerfiles/anna.dockerfile
+++ b/dockerfiles/anna.dockerfile
@@ -25,7 +25,7 @@ RUN sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trus
 RUN apt-get update
 
 # this uses --force-yes because of some disk space warning
-RUN sudo apt-get install clang-5.0 lldb-5.0 --force-yes
+RUN sudo apt-get install -y clang-5.0 lldb-5.0 --force-yes
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 1
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 1
 RUN apt-get install -y libc++-dev libc++abi-dev 
@@ -55,5 +55,6 @@ RUN rm -rf protobuf-3.5.1 protobuf-all-3.5.1.zip
 # build Bedrock
 RUN git clone https://github.com/fluent-project/fluent
 RUN cd fluent && bash scripts/build-all.sh -j4 -bRelease
+COPY start.sh /fluent/k8s/start.sh
 
 CMD bash fluent/k8s/start.sh $SERVER_TYPE

--- a/dockerfiles/kops.dockerfile
+++ b/dockerfiles/kops.dockerfile
@@ -39,8 +39,9 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 # can just provide a script to this generally, independent of running it here
 
 RUN git clone https://github.com/fluent-project/fluent
+COPY start_kops.sh /fluent/k8s/start_kops.sh
 
 # make kube root dir
 RUN mkdir /root/.kube
 
-CMD sh start_kops.sh
+CMD sh fluent/k8s/start_kops.sh

--- a/k8s/add_nodes.sh
+++ b/k8s/add_nodes.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [[ -z "$1" ]] && [[ -z "$2" ]] && [[ -z "$3" ]] && [[ -z "$4" ]]; then
   echo "Usage: ./add_node.sh <memory-nodes> <ebs-nodes> <routing-nodes> <benchmark-nodes>"

--- a/k8s/add_nodes.sh
+++ b/k8s/add_nodes.sh
@@ -22,16 +22,16 @@ if [[ -z "$1" ]] && [[ -z "$2" ]] && [[ -z "$3" ]] && [[ -z "$4" ]]; then
 fi
 
 # get the ips of all the different kinds of nodes in the system
-ROUTING_IPS=`kubectl get pods -l role=routing -o jsonpath='{.items[*].status.podIP}'`
+ROUTING_IPS=`kubectl get pods -l role=routing -o jsonpath='{.items[*].status.podIP}' 2>/dev/null`
 
 # this one should never be empty
-MON_IPS=`kubectl get pods -l role=monitoring -o jsonpath='{.items[*].status.podIP}' | tr -d '[:space:]'`
+MON_IPS=`kubectl get pods -l role=monitoring -o jsonpath='{.items[*].status.podIP}' | tr -d '[:space:]' 2>/dev/null`
 while [ "$MON_IPS" = "" ]; do
-  MON_IPS=`kubectl get pods -l role=monitoring -o jsonpath='{.items[*].status.podIP}' | tr -d '[:space:]'`
+  MON_IPS=`kubectl get pods -l role=monitoring -o jsonpath='{.items[*].status.podIP}' | tr -d '[:space:]' 2>/dev/null`
 done
 
 get_prev_num() {
-  NUM_PREV=`kubectl get pods -l role=$1 | wc -l`
+  NUM_PREV=`kubectl get pods -l role=$1 | wc -l` > /dev/null 2>&1
 
   if [ $NUM_PREV -gt 0 ]; then
     ((NUM_PREV--))
@@ -61,73 +61,74 @@ while [ $? -ne 0 ]; do
 done
 
 add_pods() {
-  NUM_PREV=$(get_prev_num $1)
+  if [[ $2 -gt 0 ]]; then
+    NUM_PREV=$(get_prev_num $1)
 
-  NAMES=`kubectl get nodes -l role=$1 --sort-by=.metadata.creationTimestamp | tail -n $2 | cut -d' ' -f1` > /dev/null 2>&1
-  IFS=' ' read -r -a IPS <<< $NAMES
+    NAMES=`kubectl get nodes -l role=$1 --sort-by=.metadata.creationTimestamp | tail -n $2 | cut -d' ' -f1 2>/dev/null`
+    IFS=' ' read -r -a IPS <<< $NAMES
 
-  for i in "${!IPS[@]}"; do
-    ID=$(($i + 1 + $NUM_PREV))
+    for i in "${!IPS[@]}"; do
+      ID=$(($i + 1 + $NUM_PREV))
 
-    kubectl label nodes ${IPS[i]} podid=$1-$ID > /dev/null 2>&1
-  done
+      kubectl label nodes ${IPS[i]} podid=$1-$ID > /dev/null 2>&1
+    done
 
-  if [ "$1" = "memory" ]; then
-    YML_FILE=yaml/pods/memory-pod.yml
-  elif [ "$1" = "benchmark" ]; then
-    YML_FILE=yaml/pods/benchmark-pod.yml
-  elif [ "$1" = "ebs" ]; then
-    YML_FILE=yaml/pods/ebs-pod.yml
-  elif [ "$1" = "routing" ]; then
-    YML_FILE=yaml/pods/routing-pod.yml
-  else
-    exit 1
-  fi
-
-  # split the proxies into an array and choose a random one as the seed
-  IFS=' ' read -ra ARR <<< "$ROUTING_IPS"
-  if [ ${#ARR[@]} -eq 0 ]; then
-    SEED_IP=""
-  else
-    SEED_IP=${ARR[$RANDOM % ${#ARR[@]}]}
-  fi
-
-  FINAL_NUM=$(($NUM_PREV + $2))
-  ((NUM_PREV++))
-
-  for i in $(seq $NUM_PREV $FINAL_NUM); do
-    sed "s|NUM_DUMMY|$i|g" $YML_FILE > tmp.yml
-
-    if [ "$1" = "ebs" ]; then
-      # create new EBS volume
-      EBS_V0=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
-      aws ec2 create-tags --resources $EBS_V0 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
-      EBS_V1=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
-      aws ec2 create-tags --resources $EBS_V1 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
-      EBS_V2=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
-      aws ec2 create-tags --resources $EBS_V2 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
-      EBS_V3=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
-      aws ec2 create-tags --resources $EBS_V3 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
-
-      # set EBS volume IDs
-      sed -i "s|VOLUME_DUMMY_0|$EBS_V0|g" tmp.yml
-      sed -i "s|VOLUME_DUMMY_1|$EBS_V1|g" tmp.yml
-      sed -i "s|VOLUME_DUMMY_2|$EBS_V2|g" tmp.yml
-      sed -i "s|VOLUME_DUMMY_3|$EBS_V3|g" tmp.yml
+    if [ "$1" = "memory" ]; then
+      YML_FILE=yaml/pods/memory-pod.yml
+    elif [ "$1" = "benchmark" ]; then
+      YML_FILE=yaml/pods/benchmark-pod.yml
+    elif [ "$1" = "ebs" ]; then
+      YML_FILE=yaml/pods/ebs-pod.yml
+    elif [ "$1" = "routing" ]; then
+      YML_FILE=yaml/pods/routing-pod.yml
+    else
+      exit 1
     fi
 
-    # set the IPs of other system components
-    sed -i "s|ROUTING_IPS_DUMMY|\"$ROUTING_IPS\"|g" tmp.yml
-    sed -i "s|MON_IPS_DUMMY|$MON_IPS|g" tmp.yml
-    sed -i "s|SEED_IP_DUMMY|$SEED_IP|g" tmp.yml
+    # split the proxies into an array and choose a random one as the seed
+    IFS=' ' read -ra ARR <<< "$ROUTING_IPS"
+    if [ ${#ARR[@]} -eq 0 ]; then
+      SEED_IP=""
+    else
+      SEED_IP=${ARR[$RANDOM % ${#ARR[@]}]}
+    fi
 
-    kubectl create -f tmp.yml > /dev/null 2>&1
-    rm tmp.yml
-  done
+    FINAL_NUM=$(($NUM_PREV + $2))
+    ((NUM_PREV++))
+
+    for i in $(seq $NUM_PREV $FINAL_NUM); do
+      sed "s|NUM_DUMMY|$i|g" $YML_FILE > tmp.yml
+
+      if [ "$1" = "ebs" ]; then
+        # create new EBS volume
+        EBS_V0=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
+        aws ec2 create-tags --resources $EBS_V0 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
+        EBS_V1=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
+        aws ec2 create-tags --resources $EBS_V1 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
+        EBS_V2=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
+        aws ec2 create-tags --resources $EBS_V2 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
+        EBS_V3=`aws ec2 create-volume --availability-zone=us-east-1a --size=64 --volume-type=gp2 | grep VolumeId | cut -d\" -f4`
+        aws ec2 create-tags --resources $EBS_V3 --tags Key=KubernetesCluster,Value=$NAME > /dev/null 2>&1
+
+        # set EBS volume IDs
+        sed -i "s|VOLUME_DUMMY_0|$EBS_V0|g" tmp.yml
+        sed -i "s|VOLUME_DUMMY_1|$EBS_V1|g" tmp.yml
+        sed -i "s|VOLUME_DUMMY_2|$EBS_V2|g" tmp.yml
+        sed -i "s|VOLUME_DUMMY_3|$EBS_V3|g" tmp.yml
+      fi
+
+      # set the IPs of other system components
+      sed -i "s|ROUTING_IPS_DUMMY|\"$ROUTING_IPS\"|g" tmp.yml
+      sed -i "s|MON_IPS_DUMMY|$MON_IPS|g" tmp.yml
+      sed -i "s|SEED_IP_DUMMY|$SEED_IP|g" tmp.yml
+
+      kubectl create -f tmp.yml > /dev/null 2>&1
+      rm tmp.yml
+    done
+  fi
 }
 
 add_pods memory $1
 add_pods ebs $2
 add_pods routing $3
 add_pods benchmark $4
-

--- a/k8s/add_servers.sh
+++ b/k8s/add_servers.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "$1" ] && [ -z "$2" ]; then
   echo "Usage: ./add_servers.sh <node-type> <new-instances> {<num-prev-instances>}"

--- a/k8s/create_cluster.sh
+++ b/k8s/create_cluster.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "$1" ] && [ -z "$2"] && [ -z "$3"] && [ -z "$4" ]; then
   echo "Usage: ./create_cluster.sh <min_mem_instances> <min_ebs_instances> <routing_instances> <benchmark_instances> {<path-to-ssh-key>}"

--- a/k8s/create_cluster.sh
+++ b/k8s/create_cluster.sh
@@ -69,12 +69,15 @@ done
 # copy kubecfg into the kops pod, so it can execute kops commands
 kubectl cp /home/ubuntu/.kube/config kops-pod:/root/.kube/config > /dev/null 2>&1
 
+echo "Adding monitoring nodes..."
 sed "s|MGMT_IP_DUMMY|$MGMT_IP|g" yaml/pods/monitoring-pod.yml > tmp.yml
 kubectl create -f tmp.yml > /dev/null 2>&1
 rm tmp.yml
 
+echo "Adding routing nodes..."
 ./add_nodes.sh 0 0 $3 0
 
+echo "Waiting for routing nodes to start..."
 # wait for all proxies to be ready
 ROUTING_IPS=`kubectl get pods -l role=routing -o jsonpath='{.items[*].status.podIP}'`
 ROUTING_IP_ARR=($ROUTING_IPS)
@@ -83,6 +86,7 @@ while [ ${#ROUTING_IP_ARR[@]} -ne $3 ]; do
   ROUTING_IP_ARR=($ROUTING_IPS)
 done
 
+echo "Starting all other kinds of nodes..."
 ./add_nodes.sh $1 $2 0 $4
 
 # copy the SSH key into the management node... doing this later because we need

--- a/k8s/remove_node.sh
+++ b/k8s/remove_node.sh
@@ -20,7 +20,7 @@ if [[ -z "$1" ]] || [[ -z "$2" ]]; then
 fi
 
 get_prev_num() {
-  NUM_PREV=`kubectl get pods -l role=$1 | wc -l`
+  NUM_PREV=`kubectl get pods -l role=$1 | wc -l` > /dev/null 2>&1
 
   if [ $NUM_PREV -gt 0 ]; then
     ((NUM_PREV--))

--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "$1" ]; then
   echo "No argument provided. Exiting."

--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -24,7 +24,7 @@ gen_yml_list() {
   RESULT=""
 
   for IP in "${ARR[@]}"; do
-    RESULT=$"$RESULT    - $IP\n"
+    RESULT=$"$RESULT        - $IP\n"
   done
 
   echo -e "$RESULT"
@@ -32,49 +32,70 @@ gen_yml_list() {
 
 cd fluent
 mkdir -p conf
-IP=`ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'`
+
+IS_EC2=`curl -s http://instance-data.ec2.internal`
+PRIVATE_IP=`ifconfig eth0 | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'`
+if [[ ! -z "$IS_EC2" ]]; then
+  PUBLIC_IP=`curl http://169.254.169.254/latest/meta-data/public-ipv4`
+else
+  PUBLIC_IP=$PRIVATE_IP
+fi
+
+
+
+echo -e "threads:" > conf/kvs-config.yml
+echo -e "    memory: 4" >> conf/kvs-config.yml
+echo -e "    ebs: 4" >> conf/kvs-config.yml
+echo -e "    benchmark: 4" >> conf/kvs-config.yml
+echo -e "    routing: 4" >> conf/kvs-config.yml
+
+echo -e "replication:" >> conf/kvs-config.yml
+echo -e "    memory: 1" >> conf/kvs-config.yml
+echo -e "    ebs: 0" >> conf/kvs-config.yml
+echo -e "    minimum: 1" >> conf/kvs-config.yml
+echo -e "    local: 1" >> conf/kvs-config.yml
 
 if [ "$1" = "mn" ]; then
-  echo -e "monitoring:" > conf/config.yml
-  echo -e "    mgmt_ip: $MGMT_IP" >> conf/config.yml
-  echo -e "    ip: $IP" >> conf/config.yml
+  echo -e "monitoring:" >> conf/kvs-config.yml
+  echo -e "    mgmt_ip: $MGMT_IP" >> conf/kvs-config.yml
+  echo -e "    ip: $PRIVATE_IP" >> conf/kvs-config.yml
 
   ./build/kvs/src/monitor/flmonitor
 elif [ "$1" = "r" ]; then
-  echo -e "routing:" > conf/config.yml
-  echo -e "    ip: $IP" >> conf/config.yml
+  echo -e "routing:" >> conf/kvs-config.yml
+  echo -e "    ip: $PRIVATE_IP" >> conf/kvs-config.yml
 
-  LST=$(gen_yml_list $MON_IPS)
-  echo -e "    monitoring:" >> conf/config.yml
-  echo -e "$LST" >> conf/config.yml
+  LST=$(gen_yml_list "$MON_IPS")
+  echo -e "    monitoring:" >> conf/kvs-config.yml
+  echo -e "$LST" >> conf/kvs-config.yml
 
   ./build/kvs/src/route/flroute
 elif [ "$1" = "b" ]; then
-  echo -e "user:" > conf/config.yml
-  echo -e "    ip: $IP" >> conf conf/config.yml
+  echo -e "user:" >> conf/kvs-config.yml
+  echo -e "    ip: $PRIVATE_IP" >> conf conf/kvs-config.yml
 
-  LST=$(gen_yml_list $MON_IPS)
-  echo -e "    monitoring:" >> conf/config.yml
-  echo -e "$LST" >> conf/config.yml
+  LST=$(gen_yml_list "$MON_IPS")
+  echo -e "    monitoring:" >> conf/kvs-config.yml
+  echo -e "$LST" >> conf/kvs-config.yml
 
   LST=$(gen_yml_list "$ROUTING_IPS")
-  echo -e "    routing:" >> conf/config.yml
-  echo -e "$LST" >> conf/config.yml
+  echo -e "    routing:" >> conf/kvs-config.yml
+  echo -e "$LST" >> conf/kvs-config.yml
 
   ./build/kvs/src/benchmark/flbench
 else
-  echo -e "server:" > conf/config.yml
-  echo -e "    seed_ip: $SEED_IP" >> conf/config.yml
-  echo -e "    ip: $IP" >> conf/config.yml
+  echo -e "server:" >> conf/kvs-config.yml
+  echo -e "    seed_ip: $SEED_IP" >> conf/kvs-config.yml
+  echo -e "    public_ip: $PUBLIC_IP" >> conf/kvs-config.yml
+  echo -e "    private_ip: $PRIVATE_IP" >> conf/kvs-config.yml
 
-  LST=$(gen_yml_list $MON_IPS)
-  echo -e "    monitoring:" >> conf/config.yml
-  echo -e "$LST" >> conf/config.yml
+  LST=$(gen_yml_list "$MON_IPS")
+  echo -e "    monitoring:" >> conf/kvs-config.yml
+  echo -e "$LST" >> conf/kvs-config.yml
 
   LST=$(gen_yml_list "$ROUTING_IPS")
-  echo -e "    routing:" >> conf/config.yml
-  echo -e "$LST" >> conf/config.yml
+  echo -e "    routing:" >> conf/kvs-config.yml
+  echo -e "$LST" >> conf/kvs-config.yml
 
   ./build/kvs/src/kvs/flkvs
 fi
-

--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -30,16 +30,16 @@ gen_yml_list() {
   echo -e "$RESULT"
 }
 
-cd tiered-storage
+cd fluent
 mkdir -p conf
-IP=`ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1}'`
+IP=`ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'`
 
 if [ "$1" = "mn" ]; then
   echo -e "monitoring:" > conf/config.yml
   echo -e "    mgmt_ip: $MGMT_IP" >> conf/config.yml
   echo -e "    ip: $IP" >> conf/config.yml
 
-  ./build/src/bedrock/monitoring
+  ./build/kvs/src/monitor/flmonitor
 elif [ "$1" = "r" ]; then
   echo -e "routing:" > conf/config.yml
   echo -e "    ip: $IP" >> conf/config.yml
@@ -48,7 +48,7 @@ elif [ "$1" = "r" ]; then
   echo -e "    monitoring:" >> conf/config.yml
   echo -e "$LST" >> conf/config.yml
 
-  ./build/src/bedrock/routing
+  ./build/kvs/src/route/flroute
 elif [ "$1" = "b" ]; then
   echo -e "user:" > conf/config.yml
   echo -e "    ip: $IP" >> conf conf/config.yml
@@ -61,7 +61,7 @@ elif [ "$1" = "b" ]; then
   echo -e "    routing:" >> conf/config.yml
   echo -e "$LST" >> conf/config.yml
 
-  ./build/src/bedrock/benchmark
+  ./build/kvs/src/benchmark/flbench
 else
   echo -e "server:" > conf/config.yml
   echo -e "    seed_ip: $SEED_IP" >> conf/config.yml
@@ -75,6 +75,6 @@ else
   echo -e "    routing:" >> conf/config.yml
   echo -e "$LST" >> conf/config.yml
 
-  ./build/src/bedrock/server
+  ./build/kvs/src/kvs/flkvs
 fi
 

--- a/k8s/start_kops.sh
+++ b/k8s/start_kops.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 # set AWS environment variables
 mkdir -p ~/.aws

--- a/k8s/start_kops.sh
+++ b/k8s/start_kops.sh
@@ -14,8 +14,6 @@
 
 #!/bin/bash
 
-cd tiered-storage
-
 # set AWS environment variables
 mkdir -p ~/.aws
 echo "[default]\nregion = us-east-1" > ~/.aws/config
@@ -23,4 +21,4 @@ echo "[default]\naws_access_key_id = $AWS_ACCESS_KEY_ID\naws_secret_access_key =
 mkdir -p ~/.ssh
 
 # start python server
-cd k8s && python3 kops_server.py
+cd fluent/k8s && python3 kops_server.py

--- a/k8s/yaml/pods/memory-pod.yml
+++ b/k8s/yaml/pods/memory-pod.yml
@@ -19,6 +19,7 @@ metadata:
   labels: 
     role: memory
 spec:
+  hostNetwork: true
   containers:
   - name: memory-container
     image: vsreekanti/anna

--- a/k8s/yaml/services/routing.yml
+++ b/k8s/yaml/services/routing.yml
@@ -13,22 +13,23 @@
 #  limitations under the License.
 
 apiVersion: v1
-kind: Pod
+kind: Service
 metadata:
-  name: routing-pod-NUM_DUMMY
-  labels: 
-    role: routing
+  name: routing-service
 spec:
-  hostNetwork: true
-  containers:
-  - name: routing-container
-    image: vsreekanti/anna
-    env: 
-    - name: SERVER_TYPE
-      value: r
-    - name: MON_IPS
-      value: MON_IPS_DUMMY
-  nodeSelector:
+  type: LoadBalancer
+  ports:
+  - port: 6000
+    targetPort: 6450
+    name: routing-0
+  - port: 6001
+    targetPort: 6451
+    name: routing-1
+  - port: 6002
+    targetPort: 6452
+    name: routing-2
+  - port: 6003
+    targetPort: 6453
+    name: routing-3
+  selector:
     role: routing
-    podid: routing-NUM_DUMMY
-  restartPolicy: Never

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -32,11 +32,11 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     return unique_servers;
   }
 
-  bool insert(Address ip, unsigned tid) {
+  bool insert(Address public_ip, Address private_ip, unsigned tid) {
     bool succeed;
     for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
          virtual_num++) {
-      ServerThread st = ServerThread(ip, tid, virtual_num);
+      ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
       succeed = ConsistentHashMap<ServerThread, H>::insert(st).second;
       if (succeed) {
         unique_servers.insert(st);
@@ -45,10 +45,10 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     return succeed;
   }
 
-  void remove(Address ip, unsigned tid) {
+  void remove(Address public_ip, Address private_ip, unsigned tid) {
     for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
          virtual_num++) {
-      ServerThread st = ServerThread(ip, tid, virtual_num);
+      ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
       unique_servers.erase(st);
       ConsistentHashMap<ServerThread, H>::erase(st);
     }

--- a/kvs/include/kvs/kvs_handlers.hpp
+++ b/kvs/include/kvs/kvs_handlers.hpp
@@ -21,7 +21,7 @@
 #include "utils/server_utils.hpp"
 
 void node_join_handler(
-    unsigned thread_id, unsigned& seed, Address ip,
+    unsigned thread_id, unsigned& seed, Address public_ip, Address private_ip,
     std::shared_ptr<spdlog::logger> logger, std::string& serialized,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
@@ -31,13 +31,13 @@ void node_join_handler(
     ServerThread& wt, AddressKeysetMap& join_addr_keyset_map);
 
 void node_depart_handler(
-    unsigned thread_id, Address ip,
+    unsigned thread_id, Address public_ip, Address private_ip,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::shared_ptr<spdlog::logger> logger, std::string& serialized,
     SocketCache& pushers);
 
 void self_depart_handler(
-    unsigned thread_id, unsigned& seed, Address ip,
+    unsigned thread_id, unsigned& seed, Address public_ip, Address private_ip,
     std::shared_ptr<spdlog::logger> logger, std::string& serialized,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
@@ -88,7 +88,7 @@ void rep_factor_response_handler(
     Serializer* serializer, SocketCache& pushers);
 
 void rep_factor_change_handler(
-    Address ip, unsigned thread_id, unsigned& seed,
+    Address public_ip, Address private_ip, unsigned thread_id, unsigned& seed,
     std::shared_ptr<spdlog::logger> logger, std::string& serialized,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,

--- a/kvs/include/kvs_types.hpp
+++ b/kvs/include/kvs_types.hpp
@@ -27,7 +27,7 @@ using StorageStat =
     std::unordered_map<Address,
                        std::unordered_map<unsigned, unsigned long long>>;
 
-using OccupancyStat = std::unordered_map<
+using OccupancyStats = std::unordered_map<
     Address, std::unordered_map<unsigned, std::pair<double, unsigned>>>;
 
 using AccessStat =

--- a/kvs/include/metadata.hpp
+++ b/kvs/include/metadata.hpp
@@ -71,9 +71,10 @@ inline Key get_metadata_key(const ServerThread& st, unsigned tier_id,
                   // MetadataType::replication
   }
 
-  return kMetadataIdentifier + kMetadataDelimiter + st.get_ip() +
-         kMetadataDelimiter + std::to_string(thread_num) + kMetadataDelimiter +
-         "tier" + std::to_string(tier_id) + kMetadataDelimiter + suffix;
+  return kMetadataIdentifier + kMetadataDelimiter + st.get_public_ip() +
+         kMetadataDelimiter + st.get_private_ip() + kMetadataDelimiter +
+         std::to_string(thread_num) + kMetadataDelimiter + "tier" +
+         std::to_string(tier_id) + kMetadataDelimiter + suffix;
 }
 
 // This version of the function should only be called with

--- a/kvs/include/monitor/monitoring_handlers.hpp
+++ b/kvs/include/monitor/monitoring_handlers.hpp
@@ -24,8 +24,8 @@ void membership_handler(
     unsigned& adding_memory_node, unsigned& adding_ebs_node,
     std::chrono::time_point<std::chrono::system_clock>& grace_start,
     std::vector<Address>& routing_address, StorageStat& memory_tier_storage,
-    StorageStat& ebs_tier_storage, OccupancyStat& memory_tier_occupancy,
-    OccupancyStat& ebs_tier_occupancy,
+    StorageStat& ebs_tier_storage, OccupancyStats& memory_tier_occupancy,
+    OccupancyStats& ebs_tier_occupancy,
     std::unordered_map<Key, std::unordered_map<Address, unsigned>>&
         key_access_frequency);
 

--- a/kvs/include/monitor/monitoring_utils.hpp
+++ b/kvs/include/monitor/monitoring_utils.hpp
@@ -65,7 +65,8 @@ struct SummaryStats {
     max_ebs_occupancy = 0;
     min_ebs_occupancy = 1;
     avg_ebs_occupancy = 0;
-    min_occupancy_memory_ip = Address();
+    min_occupancy_memory_public_ip = Address();
+    min_occupancy_memory_private_ip = Address();
     avg_latency = 0;
     total_throughput = 0;
   }
@@ -88,7 +89,8 @@ struct SummaryStats {
   double max_ebs_occupancy;
   double min_ebs_occupancy;
   double avg_ebs_occupancy;
-  Address min_occupancy_memory_ip;
+  Address min_occupancy_memory_public_ip;
+  Address min_occupancy_memory_private_ip;
   double avg_latency;
   double total_throughput;
 };
@@ -121,14 +123,14 @@ void collect_internal_stats(
         key_access_frequency,
     std::unordered_map<Key, unsigned>& key_size,
     StorageStat& memory_tier_storage, StorageStat& ebs_tier_storage,
-    OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
+    OccupancyStats& memory_tier_occupancy, OccupancyStats& ebs_tier_occupancy,
     AccessStat& memory_tier_access, AccessStat& ebs_tier_access);
 
 void compute_summary_stats(
     std::unordered_map<Key, std::unordered_map<Address, unsigned>>&
         key_access_frequency,
     StorageStat& memory_tier_storage, StorageStat& ebs_tier_storage,
-    OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
+    OccupancyStats& memory_tier_occupancy, OccupancyStats& ebs_tier_occupancy,
     AccessStat& memory_tier_access, AccessStat& ebs_tier_access,
     std::unordered_map<Key, unsigned>& key_access_summary, SummaryStats& ss,
     std::shared_ptr<spdlog::logger> logger, unsigned& server_monitoring_epoch);

--- a/kvs/include/proto/misc.proto
+++ b/kvs/include/proto/misc.proto
@@ -37,8 +37,13 @@ message KeyAccessData {
 
 message TierMembership {
   message Tier {
+    message Server {
+      required string public_ip = 1;
+      required string private_ip = 2;
+    }
+ 
     required uint32 tier_id = 1;
-    repeated string ips = 2;
+    repeated Server servers = 2;
   }
 
   required uint64 start_time = 1;

--- a/kvs/include/threads.hpp
+++ b/kvs/include/threads.hpp
@@ -47,66 +47,79 @@ const unsigned kBenchmarkCommandBasePort = 6900;
 // TODO(vikram): All the return "tcp://" + ip_ should be made into one command
 // to reduce string addition
 class ServerThread {
-  Address ip_;
+  Address public_ip_;
+  Address private_ip_;
   unsigned tid_;
   unsigned virtual_num_;
 
  public:
   ServerThread() {}
-  ServerThread(Address ip, unsigned tid) : ip_(ip), tid_(tid) {}
-  ServerThread(Address ip, unsigned tid, unsigned virtual_num) :
-      ip_(ip),
+  ServerThread(Address public_ip, Address private_ip, unsigned tid) :
+      public_ip_(public_ip),
+      private_ip_(private_ip),
+      tid_(tid) {}
+  ServerThread(Address public_ip, Address private_ip, unsigned tid,
+               unsigned virtual_num) :
+      public_ip_(public_ip),
+      private_ip_(private_ip),
       tid_(tid),
       virtual_num_(virtual_num) {}
 
-  Address get_ip() const { return ip_; }
+  Address get_public_ip() const { return public_ip_; }
+  Address get_private_ip() const { return private_ip_; }
   unsigned get_tid() const { return tid_; }
   unsigned get_virtual_num() const { return virtual_num_; }
-  std::string get_id() const { return ip_ + ":" + std::to_string(tid_); }
+  std::string get_id() const {
+    return private_ip_ + ":" + std::to_string(tid_);
+  }
   std::string get_virtual_id() const {
-    return ip_ + ":" + std::to_string(tid_) + "_" +
+    return private_ip_ + ":" + std::to_string(tid_) + "_" +
            std::to_string(virtual_num_);
   }
   Address get_node_join_connect_addr() const {
-    return "tcp://" + ip_ + ":" + std::to_string(tid_ + kNodeJoinBasePort);
+    return "tcp://" + private_ip_ + ":" +
+           std::to_string(tid_ + kNodeJoinBasePort);
   }
   Address get_node_join_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kNodeJoinBasePort);
   }
   Address get_node_depart_connect_addr() const {
-    return "tcp://" + ip_ + ":" + std::to_string(tid_ + kNodeDepartBasePort);
+    return "tcp://" + private_ip_ + ":" +
+           std::to_string(tid_ + kNodeDepartBasePort);
   }
   Address get_node_depart_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kNodeDepartBasePort);
   }
   Address get_self_depart_connect_addr() const {
-    return "tcp://" + ip_ + ":" + std::to_string(tid_ + kSelfDepartBasePort);
+    return "tcp://" + private_ip_ + ":" +
+           std::to_string(tid_ + kSelfDepartBasePort);
   }
   Address get_self_depart_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kSelfDepartBasePort);
   }
   Address get_request_pulling_connect_addr() const {
-    return "tcp://" + ip_ + ":" +
+    return "tcp://" + public_ip_ + ":" +
            std::to_string(tid_ + kServerRequestPullingBasePort);
   }
   Address get_request_pulling_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kServerRequestPullingBasePort);
   }
   Address get_replication_factor_connect_addr() const {
-    return "tcp://" + ip_ + ":" +
+    return "tcp://" + private_ip_ + ":" +
            std::to_string(tid_ + kServerReplicationFactorBasePort);
   }
   Address get_replication_factor_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kServerReplicationFactorBasePort);
   }
   Address get_gossip_connect_addr() const {
-    return "tcp://" + ip_ + ":" + std::to_string(tid_ + kGossipBasePort);
+    return "tcp://" + private_ip_ + ":" +
+           std::to_string(tid_ + kGossipBasePort);
   }
   Address get_gossip_bind_addr() const {
     return "tcp://*:" + std::to_string(tid_ + kGossipBasePort);
   }
   Address get_replication_factor_change_connect_addr() const {
-    return "tcp://" + ip_ + ":" +
+    return "tcp://" + private_ip_ + ":" +
            std::to_string(tid_ + kServerReplicationFactorChangeBasePort);
   }
   Address get_replication_factor_change_bind_addr() const {

--- a/kvs/src/hash_ring/hash_ring.cpp
+++ b/kvs/src/hash_ring/hash_ring.cpp
@@ -44,13 +44,14 @@ ServerThreadSet HashRingUtil::get_responsible_threads(
             key, kMetadataReplicationFactor, global_hash_ring_map[tier_id]);
 
         for (const ServerThread& thread : threads) {
-          Address ip = thread.get_ip();
+          Address public_ip = thread.get_public_ip();
+          Address private_ip = thread.get_private_ip();
           std::unordered_set<unsigned> tids = responsible_local(
               key, placement[key].local_replication_map_[tier_id],
               local_hash_ring_map[tier_id]);
 
           for (const unsigned& tid : tids) {
-            result.insert(ServerThread(ip, tid));
+            result.insert(ServerThread(public_ip, private_ip, tid));
           }
         }
       }
@@ -122,12 +123,13 @@ ServerThreadSet HashRingUtilInterface::get_responsible_threads_metadata(
                                                global_memory_hash_ring);
 
   for (const ServerThread& thread : threads) {
-    Address ip = thread.get_ip();
+    Address public_ip = thread.get_public_ip();
+    Address private_ip = thread.get_private_ip();
     std::unordered_set<unsigned> tids = responsible_local(
         key, kDefaultLocalReplication, local_memory_hash_ring);
 
     for (const unsigned& tid : tids) {
-      threads.insert(ServerThread(ip, tid));
+      threads.insert(ServerThread(public_ip, private_ip, tid));
     }
   }
 

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -15,7 +15,7 @@
 #include "kvs/kvs_handlers.hpp"
 
 void rep_factor_change_handler(
-    Address ip, unsigned thread_id, unsigned& seed,
+    Address public_ip, Address private_ip, unsigned thread_id, unsigned& seed,
     std::shared_ptr<spdlog::logger> logger, std::string& serialized,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
@@ -29,7 +29,7 @@ void rep_factor_change_handler(
     for (unsigned tid = 1; tid < kThreadNum; tid++) {
       kZmqUtil->send_string(
           serialized,
-          &pushers[ServerThread(ip, tid)
+          &pushers[ServerThread(public_ip, private_ip, tid)
                        .get_replication_factor_change_connect_addr()]);
     }
   }

--- a/kvs/src/kvs/utils.cpp
+++ b/kvs/src/kvs/utils.cpp
@@ -87,7 +87,7 @@ bool is_primary_replica(
     }
     auto global_pos = global_hash_ring_map[kSelfTierId].find(key);
     if (global_pos != global_hash_ring_map[kSelfTierId].end() &&
-        st.get_ip().compare(global_pos->second.get_ip()) == 0) {
+        st.get_private_ip().compare(global_pos->second.get_private_ip()) == 0) {
       auto local_pos = local_hash_ring_map[kSelfTierId].find(key);
       if (local_pos != local_hash_ring_map[kSelfTierId].end() &&
           st.get_tid() == local_pos->second.get_tid()) {

--- a/kvs/src/monitor/elasticity.cpp
+++ b/kvs/src/monitor/elasticity.cpp
@@ -30,9 +30,11 @@ void remove_node(std::shared_ptr<spdlog::logger> logger, ServerThread& node,
                  std::unordered_map<Address, unsigned>& departing_node_map,
                  MonitoringThread& mt) {
   auto connection_addr = node.get_self_depart_connect_addr();
-  departing_node_map[node.get_ip()] = kTierDataMap[1].thread_number_;
+  departing_node_map[node.get_private_ip()] = kTierDataMap[1].thread_number_;
   auto ack_addr = mt.get_depart_done_connect_addr();
-  logger->info("Removing {} node {}.", tier, node.get_ip());
+
+  logger->info("Removing node {}/{} from tier {}.", node.get_public_ip(),
+               node.get_private_ip(), tier);
   kZmqUtil->send_string(ack_addr, &pushers[connection_addr]);
   removing_flag = true;
 }

--- a/kvs/src/monitor/monitoring.cpp
+++ b/kvs/src/monitor/monitoring.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
   // form local hash rings
   for (const auto &tier_pair : kTierDataMap) {
     for (unsigned tid = 0; tid < tier_pair.second.thread_number_; tid++) {
-      local_hash_ring_map[tier_pair.first].insert(ip, tid);
+      local_hash_ring_map[tier_pair.first].insert(ip, ip, tid);
     }
   }
 
@@ -94,9 +94,9 @@ int main(int argc, char *argv[]) {
   // keep track of ebs tier storage consumption
   StorageStat ebs_tier_storage;
   // keep track of memory tier thread occupancy
-  OccupancyStat memory_tier_occupancy;
+  OccupancyStats memory_tier_occupancy;
   // keep track of ebs tier thread occupancy
-  OccupancyStat ebs_tier_occupancy;
+  OccupancyStats ebs_tier_occupancy;
   // keep track of memory tier hit
   AccessStat memory_tier_access;
   // keep track of ebs tier hit

--- a/kvs/src/monitor/slo_policy.cpp
+++ b/kvs/src/monitor/slo_policy.cpp
@@ -103,8 +103,9 @@ void slo_policy(
   } else if (ss.min_memory_occupancy < 0.05 && !removing_memory_node &&
              memory_node_number > std::max(ss.required_memory_node,
                                            (unsigned)kMinMemoryTierSize)) {
-    logger->info("Node {} is severely underutilized.",
-                 ss.min_occupancy_memory_ip);
+    logger->info("Node {}/{} is severely underutilized.",
+                 ss.min_occupancy_memory_public_ip,
+                 ss.min_occupancy_memory_private_ip);
     auto time_elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                             std::chrono::system_clock::now() - grace_start)
                             .count();
@@ -137,7 +138,8 @@ void slo_policy(
                                 local_hash_ring_map, routing_address, placement,
                                 pushers, mt, response_puller, logger, rid);
 
-      ServerThread node = ServerThread(ss.min_occupancy_memory_ip, 0);
+      ServerThread node = ServerThread(ss.min_occupancy_memory_public_ip,
+                                       ss.min_occupancy_memory_private_ip, 0);
       remove_node(logger, node, "memory", removing_memory_node, pushers,
                   departing_node_map, mt);
     }

--- a/kvs/src/route/routing.cpp
+++ b/kvs/src/route/routing.cpp
@@ -49,7 +49,8 @@ void run(unsigned thread_id, Address ip,
     // notify monitoring nodes
     for (const std::string &address : monitoring_addresses) {
       kZmqUtil->send_string(
-          "join:0:" + ip,
+          // add null because it expects two IPs from server nodes...
+          "join:0:" + ip + ":NULL",
           &pushers[MonitoringThread(address).get_notify_connect_addr()]);
     }
   }
@@ -64,7 +65,7 @@ void run(unsigned thread_id, Address ip,
   // form local hash rings
   for (const auto &tier_pair : kTierDataMap) {
     for (unsigned tid = 0; tid < tier_pair.second.thread_number_; tid++) {
-      local_hash_ring_map[tier_pair.first].insert(ip, tid);
+      local_hash_ring_map[tier_pair.first].insert(ip, ip, tid);
     }
   }
 

--- a/kvs/src/route/seed_handler.cpp
+++ b/kvs/src/route/seed_handler.cpp
@@ -30,7 +30,9 @@ std::string seed_handler(
     for (const ServerThread& st : hash_ring.get_unique_servers()) {
       TierMembership_Tier* tier = membership.add_tiers();
       tier->set_tier_id(tier_id);
-      tier->add_ips(st.get_ip());
+      auto server = tier->add_servers();
+      server->set_private_ip(st.get_private_ip());
+      server->set_public_ip(st.get_public_ip());
     }
   }
 

--- a/kvs/tests/kvs/server_handler_base.hpp
+++ b/kvs/tests/kvs/server_handler_base.hpp
@@ -49,8 +49,8 @@ class ServerHandlerTest : public ::testing::Test {
   ServerHandlerTest() {
     kvs = new MemoryKVS();
     serializer = new MemorySerializer(kvs);
-    wt = ServerThread(ip, thread_id);
-    global_hash_ring_map[1].insert(ip, thread_id);
+    wt = ServerThread(ip, ip, thread_id);
+    global_hash_ring_map[1].insert(ip, ip, thread_id);
   }
 
   virtual ~ServerHandlerTest() {

--- a/kvs/tests/kvs/test_node_depart_handler.hpp
+++ b/kvs/tests/kvs/test_node_depart_handler.hpp
@@ -16,14 +16,14 @@
 
 TEST_F(ServerHandlerTest, SimpleNodeDepart) {
   kThreadNum = 2;
-  global_hash_ring_map[1].insert("127.0.0.2", 0);
+  global_hash_ring_map[1].insert("127.0.0.2", "127.0.0.2", 0);
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 2);
 
-  std::string serialized = "1:127.0.0.2";
-  node_depart_handler(thread_id, ip, global_hash_ring_map, logger, serialized,
-                      pushers);
+  std::string serialized = "1:127.0.0.2:127.0.0.2";
+  node_depart_handler(thread_id, ip, ip, global_hash_ring_map, logger,
+                      serialized, pushers);
 
   std::vector<std::string> messages = get_zmq_messages();
 
@@ -39,8 +39,8 @@ TEST_F(ServerHandlerTest, FakeNodeDepart) {
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
   std::string serialized = "1:127.0.0.2";
-  node_depart_handler(thread_id, ip, global_hash_ring_map, logger, serialized,
-                      pushers);
+  node_depart_handler(thread_id, ip, ip, global_hash_ring_map, logger,
+                      serialized, pushers);
 
   std::vector<std::string> messages = get_zmq_messages();
 

--- a/kvs/tests/kvs/test_node_join_handler.hpp
+++ b/kvs/tests/kvs/test_node_join_handler.hpp
@@ -23,15 +23,15 @@ TEST_F(ServerHandlerTest, BasicNodeJoin) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "1:127.0.0.2";
-  node_join_handler(thread_id, seed, ip, logger, serialized,
+  std::string serialized = "1:127.0.0.2:127.0.0.2";
+  node_join_handler(thread_id, seed, ip, ip, logger, serialized,
                     global_hash_ring_map, local_hash_ring_map, key_size_map,
                     placement, join_remove_set, pushers, wt,
                     join_addr_keyset_map);
 
   std::vector<std::string> messages = get_zmq_messages();
   EXPECT_EQ(messages.size(), 2);
-  EXPECT_EQ(messages[0], std::to_string(kSelfTierId) + ":" + ip);
+  EXPECT_EQ(messages[0], std::to_string(kSelfTierId) + ":" + ip + ":" + ip);
   EXPECT_EQ(messages[1], serialized);
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
@@ -46,8 +46,8 @@ TEST_F(ServerHandlerTest, DuplicateNodeJoin) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "1:" + ip;
-  node_join_handler(thread_id, seed, ip, logger, serialized,
+  std::string serialized = "1:" + ip + ":" + ip;
+  node_join_handler(thread_id, seed, ip, ip, logger, serialized,
                     global_hash_ring_map, local_hash_ring_map, key_size_map,
                     placement, join_remove_set, pushers, wt,
                     join_addr_keyset_map);

--- a/kvs/tests/kvs/test_self_depart_handler.hpp
+++ b/kvs/tests/kvs/test_self_depart_handler.hpp
@@ -24,7 +24,7 @@ TEST_F(ServerHandlerTest, SelfDepart) {
 
   std::string serialized = "tcp://127.0.0.2:6560";
 
-  self_depart_handler(thread_id, seed, ip, logger, serialized,
+  self_depart_handler(thread_id, seed, ip, ip, logger, serialized,
                       global_hash_ring_map, local_hash_ring_map, key_size_map,
                       placement, routing_address, monitoring_address, wt,
                       pushers, serializer);
@@ -34,7 +34,7 @@ TEST_F(ServerHandlerTest, SelfDepart) {
 
   std::vector<std::string> zmq_messages = get_zmq_messages();
   EXPECT_EQ(zmq_messages.size(), 1);
-  EXPECT_EQ(zmq_messages[0], ip + "_" + std::to_string(kSelfTierId));
+  EXPECT_EQ(zmq_messages[0], ip + "_" + ip + "_" + std::to_string(kSelfTierId));
 }
 
 // TODO: test should add keys and make sure that they are gossiped elsewhere

--- a/kvs/tests/mock/mock_utils.cpp
+++ b/kvs/tests/mock/mock_utils.cpp
@@ -35,6 +35,6 @@ ServerThreadSet MockHashRingUtil::get_responsible_threads(
   ServerThreadSet threads;
   succeed = true;
 
-  threads.insert(ServerThread("127.0.0.1", 0));
+  threads.insert(ServerThread("127.0.0.1", "127.0.0.1", 0));
   return threads;
 }

--- a/kvs/tests/route/routing_handler_base.hpp
+++ b/kvs/tests/route/routing_handler_base.hpp
@@ -37,7 +37,7 @@ class RoutingHandlerTest : public ::testing::Test {
 
   RoutingHandlerTest() {
     rt = RoutingThread(ip, thread_id);
-    global_hash_ring_map[1].insert(ip, thread_id);
+    global_hash_ring_map[1].insert(ip, ip, thread_id);
   }
 
  public:

--- a/kvs/tests/route/test_membership_handler.hpp
+++ b/kvs/tests/route/test_membership_handler.hpp
@@ -18,14 +18,14 @@ TEST_F(RoutingHandlerTest, Membership) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "join:1:127.0.0.2";
+  std::string serialized = "join:1:127.0.0.2:127.0.0.2";
   membership_handler(logger, serialized, pushers, global_hash_ring_map,
                      thread_id, ip);
 
   std::vector<std::string> messages = get_zmq_messages();
 
   EXPECT_EQ(messages.size(), 1);
-  EXPECT_EQ(messages[0], "1:127.0.0.2");
+  EXPECT_EQ(messages[0], "1:127.0.0.2:127.0.0.2");
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 2);

--- a/kvs/tests/route/test_seed_handler.hpp
+++ b/kvs/tests/route/test_seed_handler.hpp
@@ -37,9 +37,10 @@ TEST_F(RoutingHandlerTest, Seed) {
   // check serialized tier size, tier_id, ip
   EXPECT_EQ(membership.tiers_size(), 1);
   for (const auto& tier : membership.tiers()) {
-    for (const std::string& other_ip : tier.ips()) {
+    for (const auto& other : tier.servers()) {
       EXPECT_EQ(tier.tier_id(), 1);
-      EXPECT_EQ(other_ip, ip);
+      EXPECT_EQ(other.private_ip(), ip);
+      EXPECT_EQ(other.public_ip(), ip);
     }
   }
 }

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 args=( -j -b -t )
 containsElement() {

--- a/scripts/check-clang.sh
+++ b/scripts/check-clang.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 cd build && make clang-format && cd ..
 

--- a/scripts/install-dependencies-osx.sh
+++ b/scripts/install-dependencies-osx.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "command -v brew" ]; then
   echo "This script requires having homebrew installed."

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "command -v clang++" ]; then
   echo "Installing clang..."

--- a/scripts/start-kvs-local.sh
+++ b/scripts/start-kvs-local.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "$1" ] && [ -z "$2" ]; then
   echo "Usage: ./scripts/start_local.sh build start-user"

--- a/scripts/stop-kvs-local.sh
+++ b/scripts/stop-kvs-local.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 if [ -z "$1" ]; then
   echo "Usage: ./scripts/stop_local.sh remove-logs"

--- a/scripts/travis/llvm-gcov.sh
+++ b/scripts/travis/llvm-gcov.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
+#  Copyright 2018 U.C. Berkeley RISE Lab
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 exec llvm-cov gcov "$@"

--- a/scripts/travis/run-tests.sh
+++ b/scripts/travis/run-tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-
-#!/bin/bash
 
 cd build && make test

--- a/scripts/travis/travis-build.sh
+++ b/scripts/travis/travis-build.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+#  Copyright 2018 U.C. Berkeley RISE Lab
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 SCRIPTS=("scripts/check-clang.sh" "kvs/tests/simple/test-simple.sh" "scripts/travis/run-tests.sh")
 
 ./scripts/build-all.sh -bDebug -t

--- a/scripts/travis/travis-install.sh
+++ b/scripts/travis/travis-install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-#!/bin/bash
 
 download_protobuf() {
   rm -rf $PROTOBUF_DIR

--- a/scripts/travis/upload-codecov.sh
+++ b/scripts/travis/upload-codecov.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #  Copyright 2018 U.C. Berkeley RISE Lab
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-
-#!/bin/bash
 
 # NOTE: This script assumes it is run from the fluent project root directory.
 cd build


### PR DESCRIPTION
* Fixes #8. 
* Allows storage servers to broadcast both public & private IPs<sup>1</sup>. 
* Enables routing access from public internet via an ELB<sup>2</sup>.
* Enables storage access from public internet via opening individual ports.

<sup>1</sup> This is because AWS has public internet facing IPs and VPC-only IPs. It seemed silly to force all communication through the public internet IP, so all communication except for GET & PUT requests can only happen via the VPC-specific IPs. Note that this exposes all ports to the *host*'s network, but only certain ports are accessible from the outside internet.
<sup>2</sup> Unlike storage servers, routing nodes are fungible. It doesn't matter which one you access as long as you access one of them, so it's easier to put them behind a single endpoint. Here, we create an elastic load balancer-based service and access routing nodes behind that.
<sup>3</sup> We automatically modify the default kops node security group to open the 4 ports on which storage servers listen for GET/PUT requests. We might want to do this in a separate security group eventually for safety reasons, but for now, none of the non-storage nodes are listening on those ports. All other ports on which communication happens are closed. 