### PR TITLE
Fix process failure protocol

### DIFF
--- a/conf/kvs-config.yml
+++ b/conf/kvs-config.yml
@@ -19,6 +19,7 @@ server:
   seed_ip: 127.0.0.1
   public_ip: 127.0.0.1
   private_ip: 127.0.0.1
+  mgmt_ip: 127.0.0.1
 ebs: ./
 threads:
   memory: 4

--- a/conf/kvs-config.yml
+++ b/conf/kvs-config.yml
@@ -19,7 +19,7 @@ server:
   seed_ip: 127.0.0.1
   public_ip: 127.0.0.1
   private_ip: 127.0.0.1
-  mgmt_ip: 127.0.0.1
+  mgmt_ip: "NULL"
 ebs: ./
 threads:
   memory: 4

--- a/k8s/add_nodes.sh
+++ b/k8s/add_nodes.sh
@@ -93,6 +93,8 @@ add_pods() {
       SEED_IP=${ARR[$RANDOM % ${#ARR[@]}]}
     fi
 
+    MGMT_IP=`kubectl get pods -l role=kops -o jsonpath='{.items[*].status.podIP}' | tr -d '[:space:]'`
+
     FINAL_NUM=$(($NUM_PREV + $2))
     ((NUM_PREV++))
 
@@ -118,6 +120,7 @@ add_pods() {
       fi
 
       # set the IPs of other system components
+      sed -i "s|MGMT_IP_DUMMY|$MGMT_IP|g" yaml/pods/monitoring-pod.yml tmp.yml
       sed -i "s|ROUTING_IPS_DUMMY|\"$ROUTING_IPS\"|g" tmp.yml
       sed -i "s|MON_IPS_DUMMY|$MON_IPS|g" tmp.yml
       sed -i "s|SEED_IP_DUMMY|$SEED_IP|g" tmp.yml

--- a/k8s/get_restart_count.sh
+++ b/k8s/get_restart_count.sh
@@ -14,5 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+sleep 3
 PNAME=`kubectl get pods -o json | jq '.items[] | select(.status.podIP=="'$1'")' | jq '.metadata.name' | cut -d\" -f2`
 kubectl get pod $PNAME -o jsonpath='{.status.containerStatuses[*].restartCount}'

--- a/k8s/get_restart_count.sh
+++ b/k8s/get_restart_count.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#  Copyright 2018 U.C. Berkeley RISE Lab
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+PNAME=`kubectl get pods -o json | jq '.items[] | select(.status.podIP=="'$1'")' | jq '.metadata.name' | cut -d\" -f2`
+kubectl get pod $PNAME -o jsonpath='{.status.containerStatuses[*].restartCount}'

--- a/k8s/kops_server.py
+++ b/k8s/kops_server.py
@@ -56,6 +56,15 @@ def run():
             else:
                 logging.error('Unexpected error while removing node %s.' % (ip))
 
+        elif args[0] == 'restart':
+            ip = args[1]
+            count = subprocess.check_output(['./get_restart_count.sh', ip])
+            logging.info('Getting restart count for IP ' + ip + '.')
 
+            resp_socket = context.socket(zmq.PUSH)
+            resp_socket.connect('tcp://' + ip + ':7000')
+            resp_socket.send_string(count)
+        else:
+            logging.info('Unknown argument type: %s.' % (args[0]))
 
 run()

--- a/k8s/kops_server.py
+++ b/k8s/kops_server.py
@@ -23,7 +23,7 @@ logging.basicConfig(filename='log.txt',level=logging.INFO)
 
 def run():
     context = zmq.Context(1)
-    request_pull_socket = context.socket(zmq.PULL)
+    request_pull_socket = context.socket(zmq.REP)
     request_pull_socket.bind('tcp://*:7000')
 
     while True:
@@ -44,7 +44,7 @@ def run():
                 logging.info('Successfully added %d %s nodes.' % (num, ntype))
             else:
                 logging.error('Unexpected error while adding nodes.')
-        elif args[0] = 'remove':
+        elif args[0] == 'remove':
             ip = args[1]
             ntype = args[2]
             logging.info('Removing %s node with IP %s.' % (ntype, ip))
@@ -58,12 +58,10 @@ def run():
 
         elif args[0] == 'restart':
             ip = args[1]
-            count = subprocess.check_output(['./get_restart_count.sh', ip])
             logging.info('Getting restart count for IP ' + ip + '.')
-
-            resp_socket = context.socket(zmq.PUSH)
-            resp_socket.connect('tcp://' + ip + ':7000')
-            resp_socket.send_string(count)
+            count = subprocess.check_output('./get_restart_count.sh ' + ip,
+                    shell=True)
+            request_pull_socket.send_string(str(count, 'utf-8'))
         else:
             logging.info('Unknown argument type: %s.' % (args[0]))
 

--- a/k8s/kops_server.py
+++ b/k8s/kops_server.py
@@ -58,9 +58,9 @@ def run():
 
         elif args[0] == 'restart':
             ip = args[1]
-            logging.info('Getting restart count for IP ' + ip + '.')
             count = subprocess.check_output('./get_restart_count.sh ' + ip,
                     shell=True)
+            logging.info('Returning restart count ' + count + ' for IP ' + ip + '.')
             request_pull_socket.send_string(str(count, 'utf-8'))
         else:
             logging.info('Unknown argument type: %s.' % (args[0]))

--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -88,6 +88,7 @@ else
   echo -e "    seed_ip: $SEED_IP" >> conf/kvs-config.yml
   echo -e "    public_ip: $PUBLIC_IP" >> conf/kvs-config.yml
   echo -e "    private_ip: $PRIVATE_IP" >> conf/kvs-config.yml
+  echo -e "    mgmt_ip: $MGMT_IP" >> conf/kvs-config.yml
 
   LST=$(gen_yml_list "$MON_IPS")
   echo -e "    monitoring:" >> conf/kvs-config.yml

--- a/k8s/yaml/pods/ebs-pod.yml
+++ b/k8s/yaml/pods/ebs-pod.yml
@@ -29,6 +29,8 @@ spec:
         value: ROUTING_IPS_DUMMY
       - name: SEED_IP
         value: SEED_IP_DUMMY
+      - name: MGMT_IP
+        value: MGMT_IP_DUMMY
       - name: MON_IPS
         value: MON_IPS_DUMMY
       volumeMounts:

--- a/k8s/yaml/pods/ebs-pod.yml
+++ b/k8s/yaml/pods/ebs-pod.yml
@@ -60,4 +60,3 @@ spec:
     awsElasticBlockStore:
       volumeID: VOLUME_DUMMY_3
       fsType: ext4
-  restartPolicy: Never

--- a/k8s/yaml/pods/memory-pod.yml
+++ b/k8s/yaml/pods/memory-pod.yml
@@ -35,4 +35,3 @@ spec:
   nodeSelector:
     role: memory
     podid: memory-NUM_DUMMY
-  restartPolicy: Never

--- a/k8s/yaml/pods/memory-pod.yml
+++ b/k8s/yaml/pods/memory-pod.yml
@@ -28,6 +28,8 @@ spec:
       value: "1"
     - name: ROUTING_IPS
       value: ROUTING_IPS_DUMMY
+    - name: MGMT_IP
+      value: MGMT_IP_DUMMY
     - name: SEED_IP
       value: SEED_IP_DUMMY
     - name: MON_IPS

--- a/k8s/yaml/pods/monitoring-pod.yml
+++ b/k8s/yaml/pods/monitoring-pod.yml
@@ -29,4 +29,3 @@ spec:
       value: MGMT_IP_DUMMY
   nodeSelector:
     role: general
-  restartPolicy: Never

--- a/k8s/yaml/pods/routing-pod.yml
+++ b/k8s/yaml/pods/routing-pod.yml
@@ -31,4 +31,3 @@ spec:
   nodeSelector:
     role: routing
     podid: routing-NUM_DUMMY
-  restartPolicy: Never

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -38,10 +38,15 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     ServerThread new_thread = ServerThread(public_ip, private_ip, tid, 0);
 
     if (unique_servers.find(new_thread) !=
-        unique_servers.end()) {  // if we already have the server, only return
-                                 // true if it's rejoining
-      return server_join_count[private_ip] < join_count;
-    } else {  // otherwise, insert it into the hash ring for the first time
+        unique_servers.end()) {  
+      // if we already have the server, only return true if it's rejoining
+      if (server_join_count[private_ip] < join_count) {
+        server_join_count[private_ip] = join_count;
+        return true;
+      }
+
+      return false;
+    } else { // otherwise, insert it into the hash ring for the first time
       unique_servers.insert(new_thread);
       server_join_count[private_ip] = join_count;
 

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -32,20 +32,23 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     return unique_servers;
   }
 
-  bool insert(Address public_ip, Address private_ip, int join_count, unsigned tid) {
+  bool insert(Address public_ip, Address private_ip, int join_count,
+              unsigned tid) {
     bool succeed;
     ServerThread new_thread = ServerThread(public_ip, private_ip, tid, 0);
 
-    if(unique_servers.contains(new_thread)) { // if we already have the server, only return true if it's rejoining
+    if (unique_servers.find(new_thread) !=
+        unique_servers.end()) {  // if we already have the server, only return
+                                 // true if it's rejoining
       return server_join_count[private_ip] < join_count;
-    } else { // otherwise, insert it into the hash ring for the first time
+    } else {  // otherwise, insert it into the hash ring for the first time
       unique_servers.insert(new_thread);
-      server_join_counts[private_ip] = join_count;
+      server_join_count[private_ip] = join_count;
 
       for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
            virtual_num++) {
         ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
-        ConsistentHashMap<ServerThread, H>::insert(st).second;
+        ConsistentHashMap<ServerThread, H>::insert(st);
       }
 
       return true;

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -34,7 +34,6 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
 
   bool insert(Address public_ip, Address private_ip, int join_count,
               unsigned tid) {
-    bool succeed;
     ServerThread new_thread = ServerThread(public_ip, private_ip, tid, 0);
 
     if (unique_servers.find(new_thread) != unique_servers.end()) {

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -37,8 +37,7 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     bool succeed;
     ServerThread new_thread = ServerThread(public_ip, private_ip, tid, 0);
 
-    if (unique_servers.find(new_thread) !=
-        unique_servers.end()) {  
+    if (unique_servers.find(new_thread) != unique_servers.end()) {
       // if we already have the server, only return true if it's rejoining
       if (server_join_count[private_ip] < join_count) {
         server_join_count[private_ip] = join_count;
@@ -46,7 +45,7 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
       }
 
       return false;
-    } else { // otherwise, insert it into the hash ring for the first time
+    } else {  // otherwise, insert it into the hash ring for the first time
       unique_servers.insert(new_thread);
       server_join_count[private_ip] = join_count;
 

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -32,30 +32,40 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
     return unique_servers;
   }
 
-  bool insert(Address public_ip, Address private_ip, unsigned tid) {
+  bool insert(Address public_ip, Address private_ip, int join_count, unsigned tid) {
     bool succeed;
-    for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
-         virtual_num++) {
-      ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
-      succeed = ConsistentHashMap<ServerThread, H>::insert(st).second;
-      if (succeed) {
-        unique_servers.insert(st);
+    ServerThread new_thread = ServerThread(public_ip, private_ip, tid, 0);
+
+    if(unique_servers.contains(new_thread)) { // if we already have the server, only return true if it's rejoining
+      return server_join_count[private_ip] < join_count;
+    } else { // otherwise, insert it into the hash ring for the first time
+      unique_servers.insert(new_thread);
+      server_join_counts[private_ip] = join_count;
+
+      for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
+           virtual_num++) {
+        ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
+        ConsistentHashMap<ServerThread, H>::insert(st).second;
       }
+
+      return true;
     }
-    return succeed;
   }
 
   void remove(Address public_ip, Address private_ip, unsigned tid) {
     for (unsigned virtual_num = 0; virtual_num < kVirtualThreadNum;
          virtual_num++) {
       ServerThread st = ServerThread(public_ip, private_ip, tid, virtual_num);
-      unique_servers.erase(st);
       ConsistentHashMap<ServerThread, H>::erase(st);
     }
+
+    unique_servers.erase(ServerThread(public_ip, private_ip, tid, 0));
+    server_join_count.erase(private_ip);
   }
 
  private:
   std::unordered_set<ServerThread, ThreadHash> unique_servers;
+  std::unordered_map<std::string, int> server_join_count;
 };
 
 typedef HashRing<GlobalHasher> GlobalHashRing;

--- a/kvs/include/kvs/kvs_handlers.hpp
+++ b/kvs/include/kvs/kvs_handlers.hpp
@@ -28,7 +28,8 @@ void node_join_handler(
     std::unordered_map<Key, unsigned>& key_stat_map,
     std::unordered_map<Key, KeyInfo>& placement,
     std::unordered_set<Key>& join_remove_set, SocketCache& pushers,
-    ServerThread& wt, AddressKeysetMap& join_addr_keyset_map);
+    ServerThread& wt, AddressKeysetMap& join_addr_keyset_map,
+    int self_join_count);
 
 void node_depart_handler(
     unsigned thread_id, Address public_ip, Address private_ip,

--- a/kvs/include/threads.hpp
+++ b/kvs/include/threads.hpp
@@ -44,6 +44,9 @@ const unsigned kUserRequestBasePort = 6800;
 const unsigned kUserKeyAddressBasePort = 6850;
 const unsigned kBenchmarkCommandBasePort = 6900;
 
+// used by the management node
+const unsigned kKopsRestartCountBasePort = 7000;
+
 // TODO(vikram): All the return "tcp://" + ip_ should be made into one command
 // to reduce string addition
 class ServerThread {
@@ -285,5 +288,10 @@ class BenchmarkThread {
   Address ip_;
   unsigned tid_;
 };
+
+inline std::string get_join_count_req_address(std::string mgmt_address) {
+  return "tcp://" + mgmt_address + ":" +
+         std::to_string(kKopsRestartCountBasePort);
+}
 
 #endif  // SRC_INCLUDE_THREADS_HPP_

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -99,7 +99,8 @@ void node_join_handler(
           // gossip the key currently -- we might be able to hack around the
           // has ring to do it more efficiently, but I'm leaving this here for
           // now
-          if ((join_count == 0 && threads.find(wt) == threads.end()) || join_count > 0) {
+          if ((join_count == 0 && threads.find(wt) == threads.end()) ||
+              join_count > 0) {
             join_remove_set.insert(key);
 
             for (const ServerThread& thread : threads) {

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -22,28 +22,32 @@ void node_join_handler(
     std::unordered_map<Key, unsigned>& key_size_map,
     std::unordered_map<Key, KeyInfo>& placement,
     std::unordered_set<Key>& join_remove_set, SocketCache& pushers,
-    ServerThread& wt, AddressKeysetMap& join_addr_keyset_map) {
+    ServerThread& wt, AddressKeysetMap& join_addr_keyset_map,
+    int self_join_count) {
   std::vector<std::string> v;
   split(serialized, ':', v);
   unsigned tier = stoi(v[0]);
   Address new_server_public_ip = v[1];
   Address new_server_private_ip = v[2];
+  int join_count = stoi(v[3]);
 
   // update global hash ring
-  bool inserted = global_hash_ring_map[tier].insert(new_server_public_ip,
-                                                    new_server_private_ip, 0);
+  bool inserted = global_hash_ring_map[tier].insert(
+      new_server_public_ip, new_server_private_ip, join_count, 0);
 
   if (inserted) {
-    logger->info("Received a node join for tier {}. New node is {}", tier,
-                 new_server_public_ip);
+    logger->info(
+        "Received a node join for tier {}. New node is {}. It's join counter "
+        "is {}.",
+        tier, new_server_public_ip, join_count);
 
-    // only thread 0 communicates with other nodes and receives distributed
-    // join messages; it communicates that information to non-0 threads on its
-    // own machine
+    // only thread 0 communicates with other nodes and receives join messages
+    // and it communicates that information to non-0 threads on its own machine
     if (thread_id == 0) {
       // send my IP to the new server node
       kZmqUtil->send_string(
-          std::to_string(kSelfTierId) + ":" + public_ip + ":" + private_ip,
+          std::to_string(kSelfTierId) + ":" + public_ip + ":" + private_ip +
+              ":" + std::to_string(self_join_count),
           &pushers[ServerThread(new_server_public_ip, new_server_private_ip, 0)
                        .get_node_join_connect_addr()]);
 

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -90,7 +90,12 @@ void node_join_handler(
             kSelfTierIdVector, succeed, seed);
 
         if (succeed) {
-          if (threads.find(wt) == threads.end()) {
+          // there are two situations in which we gossip data to the joining
+          // node:
+          // 1) if the node is a new node and I am no longer responsible for
+          // the key
+          // 2) if the node is rejoining the cluster
+          if ((join_count == 0 && threads.find(wt) == threads.end()) || join_count > 0) {
             join_remove_set.insert(key);
 
             for (const ServerThread& thread : threads) {

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -95,6 +95,10 @@ void node_join_handler(
           // 1) if the node is a new node and I am no longer responsible for
           // the key
           // 2) if the node is rejoining the cluster
+          // NOTE: This is currently inefficient because every server will
+          // gossip the key currently -- we might be able to hack around the
+          // has ring to do it more efficiently, but I'm leaving this here for
+          // now
           if ((join_count == 0 && threads.find(wt) == threads.end()) || join_count > 0) {
             join_remove_set.insert(key);
 

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -107,12 +107,16 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
   int self_join_count = stoi(count_str);
 
   // populate addresses
+  int count = 0;
   for (const auto& tier : membership.tiers()) {
     for (const auto server : tier.servers()) {
       global_hash_ring_map[tier.tier_id()].insert(server.public_ip(),
                                                   server.private_ip(), 0, 0);
     }
+    count++;
   }
+
+  logger->info("Populated {} addresses.", count);
 
   // add itself to global hash ring
   global_hash_ring_map[kSelfTierId].insert(public_ip, private_ip,

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -78,13 +78,15 @@ void user_request_handler(
         KeyTuple* tp = response.add_tuples();
         tp->set_key(key);
 
+        if (!is_metadata(key)) {
+          logger->info("Processing a {} request for key {}.", request_type, key);
+        }
+
         if (request_type == "GET") {
-          logger->info("Processing a GET request for key {}.", key);
           auto res = process_get(key, serializer);
           tp->set_value(res.first.reveal().value);
           tp->set_error(res.second);
         } else if (request_type == "PUT") {
-          logger->info("Processing a PUT request for key {} with value {}.", key, tuple.value());
           auto time_diff =
               std::chrono::duration_cast<std::chrono::milliseconds>(
                   std::chrono::system_clock::now() - start_time)

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -79,10 +79,12 @@ void user_request_handler(
         tp->set_key(key);
 
         if (request_type == "GET") {
+          logger->info("Processing a GET request for key {}.", key);
           auto res = process_get(key, serializer);
           tp->set_value(res.first.reveal().value);
           tp->set_error(res.second);
         } else if (request_type == "PUT") {
+          logger->info("Processing a PUT request for key {} with value {}.", key, tuple.value());
           auto time_diff =
               std::chrono::duration_cast<std::chrono::milliseconds>(
                   std::chrono::system_clock::now() - start_time)

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -79,7 +79,8 @@ void user_request_handler(
         tp->set_key(key);
 
         if (!is_metadata(key)) {
-          logger->info("Processing a {} request for key {}.", request_type, key);
+          logger->info("Processing a {} request for key {}.", request_type,
+                       key);
         }
 
         if (request_type == "GET") {

--- a/kvs/src/monitor/membership_handler.cpp
+++ b/kvs/src/monitor/membership_handler.cpp
@@ -38,7 +38,7 @@ void membership_handler(
                  std::to_string(tier));
     if (tier == 1) {
       global_hash_ring_map[tier].insert(new_server_public_ip,
-                                        new_server_private_ip, 0);
+                                        new_server_private_ip, 0, 0);
 
       if (adding_memory_node > 0) {
         adding_memory_node -= 1;
@@ -48,7 +48,7 @@ void membership_handler(
       grace_start = std::chrono::system_clock::now();
     } else if (tier == 2) {
       global_hash_ring_map[tier].insert(new_server_public_ip,
-                                        new_server_private_ip, 0);
+                                        new_server_private_ip, 0, 0);
 
       if (adding_ebs_node > 0) {
         adding_ebs_node -= 1;

--- a/kvs/src/monitor/monitoring.cpp
+++ b/kvs/src/monitor/monitoring.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
   // form local hash rings
   for (const auto &tier_pair : kTierDataMap) {
     for (unsigned tid = 0; tid < tier_pair.second.thread_number_; tid++) {
-      local_hash_ring_map[tier_pair.first].insert(ip, ip, tid);
+      local_hash_ring_map[tier_pair.first].insert(ip, ip, 0, tid);
     }
   }
 

--- a/kvs/src/route/membership_handler.cpp
+++ b/kvs/src/route/membership_handler.cpp
@@ -26,6 +26,7 @@ void membership_handler(
   unsigned tier = stoi(v[1]);
   Address new_server_public_ip = v[2];
   Address new_server_private_ip = v[3];
+  int join_count = stoi(v[4]);
 
   if (type == "join") {
     logger->info("Received join from server {}/{} in tier {}.",
@@ -33,8 +34,8 @@ void membership_handler(
                  std::to_string(tier));
 
     // update hash ring
-    bool inserted = global_hash_ring_map[tier].insert(new_server_public_ip,
-                                                      new_server_private_ip, 0);
+    bool inserted = global_hash_ring_map[tier].insert(
+        new_server_public_ip, new_server_private_ip, join_count, 0);
 
     if (inserted) {
       if (thread_id == 0) {

--- a/kvs/src/route/membership_handler.cpp
+++ b/kvs/src/route/membership_handler.cpp
@@ -45,13 +45,15 @@ void membership_handler(
           unsigned tier_id = global_pair.first;
           auto hash_ring = global_pair.second;
 
+          // we send a message with everything but the join because that is
+          // what the server nodes expect
+          std::string msg = v[1] + ":" + v[2] + ":" + v[3] + ":" + v[4];
+
           for (const ServerThread& st : hash_ring.get_unique_servers()) {
             // if the node is not the newly joined node, send the ip of the
             // newly joined node
             if (st.get_private_ip().compare(new_server_private_ip) != 0) {
-              kZmqUtil->send_string(std::to_string(tier) + ":" +
-                                        new_server_public_ip + ":" +
-                                        new_server_private_ip,
+              kZmqUtil->send_string(msg,
                                     &pushers[st.get_node_join_connect_addr()]);
             }
           }

--- a/kvs/src/route/membership_handler.cpp
+++ b/kvs/src/route/membership_handler.cpp
@@ -47,6 +47,8 @@ void membership_handler(
 
           // we send a message with everything but the join because that is
           // what the server nodes expect
+          // NOTE: this seems like a bit of a hack right now -- should we have
+          // a less ad-hoc way of doing message generation?
           std::string msg = v[1] + ":" + v[2] + ":" + v[3] + ":" + v[4];
 
           for (const ServerThread& st : hash_ring.get_unique_servers()) {

--- a/kvs/src/route/routing.cpp
+++ b/kvs/src/route/routing.cpp
@@ -65,7 +65,7 @@ void run(unsigned thread_id, Address ip,
   // form local hash rings
   for (const auto &tier_pair : kTierDataMap) {
     for (unsigned tid = 0; tid < tier_pair.second.thread_number_; tid++) {
-      local_hash_ring_map[tier_pair.first].insert(ip, ip, tid);
+      local_hash_ring_map[tier_pair.first].insert(ip, ip, 0, tid);
     }
   }
 

--- a/kvs/tests/kvs/server_handler_base.hpp
+++ b/kvs/tests/kvs/server_handler_base.hpp
@@ -50,7 +50,7 @@ class ServerHandlerTest : public ::testing::Test {
     kvs = new MemoryKVS();
     serializer = new MemorySerializer(kvs);
     wt = ServerThread(ip, ip, thread_id);
-    global_hash_ring_map[1].insert(ip, ip, thread_id);
+    global_hash_ring_map[1].insert(ip, ip, 0, thread_id);
   }
 
   virtual ~ServerHandlerTest() {

--- a/kvs/tests/kvs/test_node_depart_handler.hpp
+++ b/kvs/tests/kvs/test_node_depart_handler.hpp
@@ -16,7 +16,7 @@
 
 TEST_F(ServerHandlerTest, SimpleNodeDepart) {
   kThreadNum = 2;
-  global_hash_ring_map[1].insert("127.0.0.2", "127.0.0.2", 0);
+  global_hash_ring_map[1].insert("127.0.0.2", "127.0.0.2", 0, 0);
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 2);

--- a/kvs/tests/kvs/test_node_join_handler.hpp
+++ b/kvs/tests/kvs/test_node_join_handler.hpp
@@ -23,15 +23,16 @@ TEST_F(ServerHandlerTest, BasicNodeJoin) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "1:127.0.0.2:127.0.0.2";
+  std::string serialized = "1:127.0.0.2:127.0.0.2:0";
   node_join_handler(thread_id, seed, ip, ip, logger, serialized,
                     global_hash_ring_map, local_hash_ring_map, key_size_map,
                     placement, join_remove_set, pushers, wt,
-                    join_addr_keyset_map);
+                    join_addr_keyset_map, 0);
 
   std::vector<std::string> messages = get_zmq_messages();
   EXPECT_EQ(messages.size(), 2);
-  EXPECT_EQ(messages[0], std::to_string(kSelfTierId) + ":" + ip + ":" + ip);
+  EXPECT_EQ(messages[0],
+            std::to_string(kSelfTierId) + ":" + ip + ":" + ip + ":0");
   EXPECT_EQ(messages[1], serialized);
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
@@ -46,11 +47,11 @@ TEST_F(ServerHandlerTest, DuplicateNodeJoin) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "1:" + ip + ":" + ip;
+  std::string serialized = "1:" + ip + ":" + ip + ":0";
   node_join_handler(thread_id, seed, ip, ip, logger, serialized,
                     global_hash_ring_map, local_hash_ring_map, key_size_map,
                     placement, join_remove_set, pushers, wt,
-                    join_addr_keyset_map);
+                    join_addr_keyset_map, 0);
 
   std::vector<std::string> messages = get_zmq_messages();
   EXPECT_EQ(messages.size(), 0);

--- a/kvs/tests/route/routing_handler_base.hpp
+++ b/kvs/tests/route/routing_handler_base.hpp
@@ -37,7 +37,7 @@ class RoutingHandlerTest : public ::testing::Test {
 
   RoutingHandlerTest() {
     rt = RoutingThread(ip, thread_id);
-    global_hash_ring_map[1].insert(ip, ip, thread_id);
+    global_hash_ring_map[1].insert(ip, ip, 0, thread_id);
   }
 
  public:

--- a/kvs/tests/route/test_membership_handler.hpp
+++ b/kvs/tests/route/test_membership_handler.hpp
@@ -18,7 +18,7 @@ TEST_F(RoutingHandlerTest, Membership) {
   EXPECT_EQ(global_hash_ring_map[1].size(), 3000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 1);
 
-  std::string serialized = "join:1:127.0.0.2:127.0.0.2";
+  std::string serialized = "join:1:127.0.0.2:127.0.0.2:0";
   membership_handler(logger, serialized, pushers, global_hash_ring_map,
                      thread_id, ip);
 

--- a/kvs/tests/route/test_membership_handler.hpp
+++ b/kvs/tests/route/test_membership_handler.hpp
@@ -25,7 +25,7 @@ TEST_F(RoutingHandlerTest, Membership) {
   std::vector<std::string> messages = get_zmq_messages();
 
   EXPECT_EQ(messages.size(), 1);
-  EXPECT_EQ(messages[0], "1:127.0.0.2:127.0.0.2");
+  EXPECT_EQ(messages[0], "1:127.0.0.2:127.0.0.2:0");
 
   EXPECT_EQ(global_hash_ring_map[1].size(), 6000);
   EXPECT_EQ(global_hash_ring_map[1].get_unique_servers().size(), 2);


### PR DESCRIPTION
This PR is step 1 of fixing the problems described in #2 by addressing process failure. 

When a server process fails, Kubernetes will immediately restart it on the same machine where it was running before, meaning it has the same IP address. We use this fact to avoid updating the hash ring and regossip the data. Changes in this PR include:

* Pods now automatically restart when the process fails.
* The `kops-pod` responds to requests for restart count of a pod.
* The hash ring API accounts for a restart count per node -- when a node is restarting, the hash ring returns `true` on insertion, even if the hash ring size hasn't changed.