### PR TITLE
Modifies hash ring to expose ordered data structures

### DIFF
--- a/kvs/include/common.hpp
+++ b/kvs/include/common.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <algorithm>
 
 #include "kvs_types.hpp"
 #include "misc.pb.h"

--- a/kvs/include/common.hpp
+++ b/kvs/include/common.hpp
@@ -15,10 +15,10 @@
 #ifndef SRC_INCLUDE_COMMON_HPP_
 #define SRC_INCLUDE_COMMON_HPP_
 
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
 
 #include "kvs_types.hpp"
 #include "misc.pb.h"

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -79,14 +79,14 @@ typedef HashRing<LocalHasher> LocalHashRing;
 
 class HashRingUtilInterface {
  public:
-  virtual ServerThreadSet get_responsible_threads(
+  virtual ServerThreadList get_responsible_threads(
       Address respond_address, const Key& key, bool metadata,
       std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
       std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
       std::unordered_map<Key, KeyInfo>& placement, SocketCache& pushers,
       const std::vector<unsigned>& tier_ids, bool& succeed, unsigned& seed) = 0;
 
-  ServerThreadSet get_responsible_threads_metadata(
+  ServerThreadList get_responsible_threads_metadata(
       const Key& key, GlobalHashRing& global_memory_hash_ring,
       LocalHashRing& local_memory_hash_ring);
 
@@ -110,7 +110,7 @@ class HashRingUtilInterface {
 
 class HashRingUtil : public HashRingUtilInterface {
  public:
-  virtual ServerThreadSet get_responsible_threads(
+  virtual ServerThreadList get_responsible_threads(
       Address respond_address, const Key& key, bool metadata,
       std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
       std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
@@ -118,7 +118,7 @@ class HashRingUtil : public HashRingUtilInterface {
       const std::vector<unsigned>& tier_ids, bool& succeed, unsigned& seed);
 };
 
-ServerThreadSet responsible_global(const Key& key, unsigned global_rep,
+ServerThreadList responsible_global(const Key& key, unsigned global_rep,
                                    GlobalHashRing& global_hash_ring);
 
 std::unordered_set<unsigned> responsible_local(const Key& key,

--- a/kvs/include/hash_ring.hpp
+++ b/kvs/include/hash_ring.hpp
@@ -119,7 +119,7 @@ class HashRingUtil : public HashRingUtilInterface {
 };
 
 ServerThreadList responsible_global(const Key& key, unsigned global_rep,
-                                   GlobalHashRing& global_hash_ring);
+                                    GlobalHashRing& global_hash_ring);
 
 std::unordered_set<unsigned> responsible_local(const Key& key,
                                                unsigned local_rep,

--- a/kvs/include/hashers.hpp
+++ b/kvs/include/hashers.hpp
@@ -29,7 +29,7 @@ struct ThreadHash {
 // it seems like it should actually be in threads.hpp; that doesn't compile
 // because that file gets compiled before this one (and there is a circular
 // dependency between the two?)... not completely sure how to fix this
-typedef std::unordered_set<ServerThread, ThreadHash> ServerThreadSet;
+// typedef std::unordered_set<ServerThread, ThreadHash> ServerThreadSet;
 typedef std::vector<ServerThread> ServerThreadList;
 
 struct GlobalHasher {

--- a/kvs/include/hashers.hpp
+++ b/kvs/include/hashers.hpp
@@ -15,7 +15,8 @@
 #ifndef SRC_INCLUDE_HASHERS_HPP_
 #define SRC_INCLUDE_HASHERS_HPP_
 
-#include <unordered_set>
+//#include <unordered_set>
+#include <vector>
 #include "threads.hpp"
 
 struct ThreadHash {
@@ -29,6 +30,7 @@ struct ThreadHash {
 // because that file gets compiled before this one (and there is a circular
 // dependency between the two?)... not completely sure how to fix this
 typedef std::unordered_set<ServerThread, ThreadHash> ServerThreadSet;
+typedef std::vector<ServerThread> ServerThreadList;
 
 struct GlobalHasher {
   uint32_t operator()(const ServerThread& th) {

--- a/kvs/include/hashers.hpp
+++ b/kvs/include/hashers.hpp
@@ -15,7 +15,6 @@
 #ifndef SRC_INCLUDE_HASHERS_HPP_
 #define SRC_INCLUDE_HASHERS_HPP_
 
-//#include <unordered_set>
 #include <vector>
 #include "threads.hpp"
 
@@ -29,7 +28,6 @@ struct ThreadHash {
 // it seems like it should actually be in threads.hpp; that doesn't compile
 // because that file gets compiled before this one (and there is a circular
 // dependency between the two?)... not completely sure how to fix this
-// typedef std::unordered_set<ServerThread, ThreadHash> ServerThreadSet;
 typedef std::vector<ServerThread> ServerThreadList;
 
 struct GlobalHasher {

--- a/kvs/src/hash_ring/hash_ring.cpp
+++ b/kvs/src/hash_ring/hash_ring.cpp
@@ -75,15 +75,14 @@ ServerThreadList responsible_global(const Key& key, unsigned global_rep,
     unsigned i = 0;
 
     while (i < global_rep) {
-      //bool succeed = threads.insert(pos->second).second;
-      threads.push_back(pos->second);
+      if (std::find(threads.begin(), threads.end(), pos->second) == 
+          threads.end()) { 
+        threads.push_back(pos->second);
+        i += 1;
+      }
       if (++pos == global_hash_ring.end()) {
         pos = global_hash_ring.begin();
       }
-
-      //if (succeed) {
-      i += 1;
-      //}
     }
   }
 

--- a/kvs/src/hash_ring/hash_ring.cpp
+++ b/kvs/src/hash_ring/hash_ring.cpp
@@ -66,7 +66,7 @@ ServerThreadList HashRingUtil::get_responsible_threads(
 // assuming the replication factor will never be greater than the number of
 // nodes in a tier return a set of ServerThreads that are responsible for a key
 ServerThreadList responsible_global(const Key& key, unsigned global_rep,
-                                   GlobalHashRing& global_hash_ring) {
+                                    GlobalHashRing& global_hash_ring) {
   ServerThreadList threads;
   auto pos = global_hash_ring.find(key);
 
@@ -75,8 +75,8 @@ ServerThreadList responsible_global(const Key& key, unsigned global_rep,
     unsigned i = 0;
 
     while (i < global_rep) {
-      if (std::find(threads.begin(), threads.end(), pos->second) == 
-          threads.end()) { 
+      if (std::find(threads.begin(), threads.end(), pos->second) ==
+          threads.end()) {
         threads.push_back(pos->second);
         i += 1;
       }
@@ -120,7 +120,7 @@ ServerThreadList HashRingUtilInterface::get_responsible_threads_metadata(
     const Key& key, GlobalHashRing& global_memory_hash_ring,
     LocalHashRing& local_memory_hash_ring) {
   ServerThreadList threads = responsible_global(key, kMetadataReplicationFactor,
-                                               global_memory_hash_ring);
+                                                global_memory_hash_ring);
 
   for (const ServerThread& thread : threads) {
     Address public_ip = thread.get_public_ip();

--- a/kvs/src/kvs/gossip_handler.cpp
+++ b/kvs/src/kvs/gossip_handler.cpp
@@ -39,9 +39,6 @@ void gossip_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      //if (threads.find(wt) !=
-      //    threads.end()) {  // this means this worker thread is one of the
-      //                      // responsible threads
       if (std::find(threads.begin(), threads.end(), wt) !=
           threads.end()) {  // this means this worker thread is one of the
                             // responsible threads

--- a/kvs/src/kvs/gossip_handler.cpp
+++ b/kvs/src/kvs/gossip_handler.cpp
@@ -33,13 +33,16 @@ void gossip_handler(
   for (const KeyTuple& tuple : gossip.tuples()) {
     // first check if the thread is responsible for the key
     Key key = tuple.key();
-    ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+    ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.get_replication_factor_connect_addr(), key, is_metadata(key),
         global_hash_ring_map, local_hash_ring_map, placement, pushers,
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      if (threads.find(wt) !=
+      //if (threads.find(wt) !=
+      //    threads.end()) {  // this means this worker thread is one of the
+      //                      // responsible threads
+      if (std::find(threads.begin(), threads.end(), wt) !=
           threads.end()) {  // this means this worker thread is one of the
                             // responsible threads
         process_put(tuple.key(), tuple.timestamp(), tuple.value(), serializer,

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -110,7 +110,7 @@ void node_join_handler(
             }
           } else if ((join_count == 0 &&
                       std::find(threads.begin(), threads.end(), wt) ==
-                                threads.end())) {
+                          threads.end())) {
             join_remove_set.insert(key);
 
             int local_rep = placement[key].local_replication_map_[tier];

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -108,17 +108,11 @@ void node_join_handler(
                     key);
               }
             }
-          //} else if ((join_count == 0 && threads.find(wt) == threads.end())) {
           } else if ((join_count == 0 && std::find(threads.begin(), threads.end(), wt) == threads.end())) {
             join_remove_set.insert(key);
             ServerThread first_thread = threads.front();
             join_addr_keyset_map[first_thread.get_gossip_connect_addr()].insert(
                 key);
-            // for (const ServerThread& thread : threads) {
-              // join_addr_keyset_map[thread.get_gossip_connect_addr()].insert(
-                  // key);
-              // return; 
-            // }
           }
         } else {
           logger->error(

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -112,9 +112,13 @@ void node_join_handler(
                       std::find(threads.begin(), threads.end(), wt) == 
                                 threads.end())) {
             join_remove_set.insert(key);
-            ServerThread first_thread = threads.front();
-            join_addr_keyset_map[first_thread.get_gossip_connect_addr()].insert(
-                key);
+
+            int local_rep = placement[key].local_replication_map_[tier];
+            for (int i = 0; i < local_rep; i++) {
+              ServerThread thread = threads[i];
+              join_addr_keyset_map[thread.get_gossip_connect_addr()].insert(
+                  key);
+            }
           }
         } else {
           logger->error(

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -84,7 +84,7 @@ void node_join_handler(
 
       for (const auto& key_pair : key_size_map) {
         Key key = key_pair.first;
-        ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+        ServerThreadList threads = kHashRingUtil->get_responsible_threads(
             wt.get_replication_factor_connect_addr(), key, is_metadata(key),
             global_hash_ring_map, local_hash_ring_map, placement, pushers,
             kSelfTierIdVector, succeed, seed);
@@ -108,12 +108,14 @@ void node_join_handler(
                     key);
               }
             }
-          } else if ((join_count == 0 && threads.find(wt) == threads.end())) {
+          //} else if ((join_count == 0 && threads.find(wt) == threads.end())) {
+          } else if ((join_count == 0 && std::find(threads.begin(), threads.end(), wt) == threads.end())) {
             join_remove_set.insert(key);
 
             for (const ServerThread& thread : threads) {
               join_addr_keyset_map[thread.get_gossip_connect_addr()].insert(
                   key);
+              //return; //TODO hacky, but stop after first thread sends gossip
             }
           }
         } else {

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -108,7 +108,9 @@ void node_join_handler(
                     key);
               }
             }
-          } else if ((join_count == 0 && std::find(threads.begin(), threads.end(), wt) == threads.end())) {
+          } else if ((join_count == 0 && 
+                      std::find(threads.begin(), threads.end(), wt) == 
+                                threads.end())) {
             join_remove_set.insert(key);
             ServerThread first_thread = threads.front();
             join_addr_keyset_map[first_thread.get_gossip_connect_addr()].insert(

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -108,8 +108,8 @@ void node_join_handler(
                     key);
               }
             }
-          } else if ((join_count == 0 && 
-                      std::find(threads.begin(), threads.end(), wt) == 
+          } else if ((join_count == 0 &&
+                      std::find(threads.begin(), threads.end(), wt) ==
                                 threads.end())) {
             join_remove_set.insert(key);
 

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -111,12 +111,14 @@ void node_join_handler(
           //} else if ((join_count == 0 && threads.find(wt) == threads.end())) {
           } else if ((join_count == 0 && std::find(threads.begin(), threads.end(), wt) == threads.end())) {
             join_remove_set.insert(key);
-
-            for (const ServerThread& thread : threads) {
-              join_addr_keyset_map[thread.get_gossip_connect_addr()].insert(
-                  key);
-              //return; //TODO hacky, but stop after first thread sends gossip
-            }
+            ServerThread first_thread = threads.front();
+            join_addr_keyset_map[first_thread.get_gossip_connect_addr()].insert(
+                key);
+            // for (const ServerThread& thread : threads) {
+              // join_addr_keyset_map[thread.get_gossip_connect_addr()].insert(
+                  // key);
+              // return; 
+            // }
           }
         } else {
           logger->error(

--- a/kvs/src/kvs/node_join_handler.cpp
+++ b/kvs/src/kvs/node_join_handler.cpp
@@ -112,7 +112,6 @@ void node_join_handler(
                       std::find(threads.begin(), threads.end(), wt) ==
                           threads.end())) {
             join_remove_set.insert(key);
-
             int local_rep = placement[key].local_replication_map_[tier];
             for (int i = 0; i < local_rep; i++) {
               ServerThread thread = threads[i];

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -84,9 +84,9 @@ void rep_factor_change_handler(
             kAllTierIds, succeed, seed);
 
         if (succeed) {
-          if (std::find(threads.begin(),
-                        threads.end(), wt) == threads.end()) {  // this thread is no longer
-                                                                // responsible for this key
+          if (std::find(threads.begin(), threads.end(), wt) ==
+              threads.end()) {  // this thread is no longer
+                                // responsible for this key
             remove_set.insert(key);
 
             // add all the new threads that this key should be sent to
@@ -104,7 +104,7 @@ void rep_factor_change_handler(
 
             for (const ServerThread& thread : threads) {
               if (std::find(orig_threads.begin(), orig_threads.end(), thread) ==
-                            orig_threads.end()) {
+                  orig_threads.end()) {
                 new_threads.insert(thread);
               }
             }

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -49,7 +49,7 @@ void rep_factor_change_handler(
 
     // if this thread was responsible for the key before the change
     if (key_size_map.find(key) != key_size_map.end()) {
-      ServerThreadSet orig_threads = kHashRingUtil->get_responsible_threads(
+      ServerThreadList orig_threads = kHashRingUtil->get_responsible_threads(
           wt.get_replication_factor_connect_addr(), key, is_metadata(key),
           global_hash_ring_map, local_hash_ring_map, placement, pushers,
           kAllTierIds, succeed, seed);
@@ -78,14 +78,16 @@ void rep_factor_change_handler(
               local.replication_factor();
         }
 
-        ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+        ServerThreadList threads = kHashRingUtil->get_responsible_threads(
             wt.get_replication_factor_connect_addr(), key, is_metadata(key),
             global_hash_ring_map, local_hash_ring_map, placement, pushers,
             kAllTierIds, succeed, seed);
 
         if (succeed) {
-          if (threads.find(wt) == threads.end()) {  // this thread is no longer
-                                                    // responsible for this key
+          //if (threads.find(wt) == threads.end()) {  // this thread is no longer
+          //                                          // responsible for this key
+          if (std::find(threads.begin(), threads.end(), wt) == threads.end()) {  // this thread is no longer
+                                       // responsible for this key
             remove_set.insert(key);
 
             // add all the new threads that this key should be sent to
@@ -102,7 +104,8 @@ void rep_factor_change_handler(
             std::unordered_set<ServerThread, ThreadHash> new_threads;
 
             for (const ServerThread& thread : threads) {
-              if (orig_threads.find(thread) == orig_threads.end()) {
+              //if (orig_threads.find(thread) == orig_threads.end()) {
+              if (std::find(threads.begin(), threads.end(), thread) == orig_threads.end()) {
                 new_threads.insert(thread);
               }
             }

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -84,7 +84,7 @@ void rep_factor_change_handler(
             kAllTierIds, succeed, seed);
 
         if (succeed) {
-          if (std::find(threads.begin(), 
+          if (std::find(threads.begin(),
                         threads.end(), wt) == threads.end()) {  // this thread is no longer
                                                                 // responsible for this key
             remove_set.insert(key);
@@ -103,7 +103,7 @@ void rep_factor_change_handler(
             std::unordered_set<ServerThread, ThreadHash> new_threads;
 
             for (const ServerThread& thread : threads) {
-              if (std::find(threads.begin(), threads.end(), thread) == 
+              if (std::find(orig_threads.begin(), orig_threads.end(), thread) ==
                             orig_threads.end()) {
                 new_threads.insert(thread);
               }

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -84,10 +84,8 @@ void rep_factor_change_handler(
             kAllTierIds, succeed, seed);
 
         if (succeed) {
-          //if (threads.find(wt) == threads.end()) {  // this thread is no longer
-          //                                          // responsible for this key
           if (std::find(threads.begin(), threads.end(), wt) == threads.end()) {  // this thread is no longer
-                                       // responsible for this key
+                                                                                 // responsible for this key
             remove_set.insert(key);
 
             // add all the new threads that this key should be sent to
@@ -104,7 +102,6 @@ void rep_factor_change_handler(
             std::unordered_set<ServerThread, ThreadHash> new_threads;
 
             for (const ServerThread& thread : threads) {
-              //if (orig_threads.find(thread) == orig_threads.end()) {
               if (std::find(threads.begin(), threads.end(), thread) == orig_threads.end()) {
                 new_threads.insert(thread);
               }

--- a/kvs/src/kvs/rep_factor_change_handler.cpp
+++ b/kvs/src/kvs/rep_factor_change_handler.cpp
@@ -84,8 +84,9 @@ void rep_factor_change_handler(
             kAllTierIds, succeed, seed);
 
         if (succeed) {
-          if (std::find(threads.begin(), threads.end(), wt) == threads.end()) {  // this thread is no longer
-                                                                                 // responsible for this key
+          if (std::find(threads.begin(), 
+                        threads.end(), wt) == threads.end()) {  // this thread is no longer
+                                                                // responsible for this key
             remove_set.insert(key);
 
             // add all the new threads that this key should be sent to
@@ -102,7 +103,8 @@ void rep_factor_change_handler(
             std::unordered_set<ServerThread, ThreadHash> new_threads;
 
             for (const ServerThread& thread : threads) {
-              if (std::find(threads.begin(), threads.end(), thread) == orig_threads.end()) {
+              if (std::find(threads.begin(), threads.end(), thread) == 
+                            orig_threads.end()) {
                 new_threads.insert(thread);
               }
             }

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -81,7 +81,8 @@ void rep_factor_response_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      bool responsible = std::find(threads.begin(), threads.end(), wt) != threads.end();
+      bool responsible = std::find(threads.begin(), threads.end(), wt) != 
+                                   threads.end();
 
       for (const PendingRequest& request : pending_request_map[key]) {
         auto now = std::chrono::system_clock::now();

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -174,8 +174,7 @@ void rep_factor_response_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      //if (threads.find(wt) != threads.end()) {
-      if (!(wt == threads.back())) {
+      if (std::find(threads.begin(), threads.end(), wt) != threads.end()) {
         for (const PendingGossip& gossip : pending_gossip_map[key]) {
           process_put(key, gossip.ts_, gossip.value_, serializer, key_size_map);
         }

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -75,13 +75,14 @@ void rep_factor_response_handler(
   bool succeed;
 
   if (pending_request_map.find(key) != pending_request_map.end()) {
-    ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+    ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.get_replication_factor_connect_addr(), key, is_metadata(key),
         global_hash_ring_map, local_hash_ring_map, placement, pushers,
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      bool responsible = threads.find(wt) != threads.end();
+      //bool responsible = threads.find(wt) != threads.end();
+      bool responsible = std::find(threads.begin(), threads.end(), wt) != threads.end();
 
       for (const PendingRequest& request : pending_request_map[key]) {
         auto now = std::chrono::system_clock::now();
@@ -167,13 +168,14 @@ void rep_factor_response_handler(
   }
 
   if (pending_gossip_map.find(key) != pending_gossip_map.end()) {
-    ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+    ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.get_replication_factor_connect_addr(), key, is_metadata(key),
         global_hash_ring_map, local_hash_ring_map, placement, pushers,
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      if (threads.find(wt) != threads.end()) {
+      //if (threads.find(wt) != threads.end()) {
+      if (!(wt == threads.back())) {
         for (const PendingGossip& gossip : pending_gossip_map[key]) {
           process_put(key, gossip.ts_, gossip.value_, serializer, key_size_map);
         }

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -81,7 +81,7 @@ void rep_factor_response_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      bool responsible = std::find(threads.begin(), threads.end(), wt) != 
+      bool responsible = std::find(threads.begin(), threads.end(), wt) !=
                                    threads.end();
 
       for (const PendingRequest& request : pending_request_map[key]) {

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -81,8 +81,8 @@ void rep_factor_response_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      bool responsible = std::find(threads.begin(), threads.end(), wt) !=
-                                   threads.end();
+      bool responsible =
+          std::find(threads.begin(), threads.end(), wt) != threads.end();
 
       for (const PendingRequest& request : pending_request_map[key]) {
         auto now = std::chrono::system_clock::now();

--- a/kvs/src/kvs/rep_factor_response_handler.cpp
+++ b/kvs/src/kvs/rep_factor_response_handler.cpp
@@ -81,7 +81,6 @@ void rep_factor_response_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      //bool responsible = threads.find(wt) != threads.end();
       bool responsible = std::find(threads.begin(), threads.end(), wt) != threads.end();
 
       for (const PendingRequest& request : pending_request_map[key]) {

--- a/kvs/src/kvs/self_depart_handler.cpp
+++ b/kvs/src/kvs/self_depart_handler.cpp
@@ -69,7 +69,7 @@ void self_depart_handler(
 
   for (const auto& key_pair : key_size_map) {
     Key key = key_pair.first;
-    ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+    ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.get_replication_factor_connect_addr(), key, is_metadata(key),
         global_hash_ring_map, local_hash_ring_map, placement, pushers,
         kAllTierIds, succeed, seed);

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -364,7 +364,7 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
 
         bool succeed;
         for (const Key& key : local_changeset) {
-          ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+          ServerThreadList threads = kHashRingUtil->get_responsible_threads(
               wt.get_replication_factor_connect_addr(), key, is_metadata(key),
               global_hash_ring_map, local_hash_ring_map, placement, pushers,
               kAllTierIds, succeed, seed);

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -51,13 +51,14 @@ void user_request_handler(
     Key key = tuple.key();
     std::string value = tuple.has_value() ? tuple.value() : "";
 
-    ServerThreadSet threads = kHashRingUtil->get_responsible_threads(
+    ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.get_replication_factor_connect_addr(), key, is_metadata(key),
         global_hash_ring_map, local_hash_ring_map, placement, pushers,
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      if (threads.find(wt) == threads.end()) {
+      //if (threads.find(wt) == threads.end()) {
+      if (std::find(threads.begin(), threads.end(), wt) == threads.enendd()) {
         if (is_metadata(key)) {
           // this means that this node is not responsible for this metadata key
           KeyTuple* tp = response.add_tuples();

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -57,7 +57,6 @@ void user_request_handler(
         kSelfTierIdVector, succeed, seed);
 
     if (succeed) {
-      //if (threads.find(wt) == threads.end()) {
       if (std::find(threads.begin(), threads.end(), wt) == threads.end()) {
         if (is_metadata(key)) {
           // this means that this node is not responsible for this metadata key

--- a/kvs/src/kvs/user_request_handler.cpp
+++ b/kvs/src/kvs/user_request_handler.cpp
@@ -58,7 +58,7 @@ void user_request_handler(
 
     if (succeed) {
       //if (threads.find(wt) == threads.end()) {
-      if (std::find(threads.begin(), threads.end(), wt) == threads.enendd()) {
+      if (std::find(threads.begin(), threads.end(), wt) == threads.end()) {
         if (is_metadata(key)) {
           // this means that this node is not responsible for this metadata key
           KeyTuple* tp = response.add_tuples();

--- a/kvs/src/monitor/replication_helpers.cpp
+++ b/kvs/src/monitor/replication_helpers.cpp
@@ -140,7 +140,7 @@ void change_replication_factor(
         unsigned rep =
             std::max(placement[key].global_replication_map_[tier],
                      orig_placement_info[key].global_replication_map_[tier]);
-        ServerThreadSet threads =
+        ServerThreadList threads =
             responsible_global(key, rep, global_hash_ring_map[tier]);
 
         for (const ServerThread& thread : threads) {

--- a/kvs/src/route/address_handler.cpp
+++ b/kvs/src/route/address_handler.cpp
@@ -43,7 +43,7 @@ void address_handler(
   } else {  // if there are servers, attempt to return the correct threads
     for (const Key& key : addr_request.keys()) {
       unsigned tier_id = 1;
-      ServerThreadSet threads = {};
+      ServerThreadList threads = {};
 
       while (threads.size() == 0 && tier_id < kMaxTier) {
         threads = kHashRingUtil->get_responsible_threads(

--- a/kvs/src/route/replication_response_handler.cpp
+++ b/kvs/src/route/replication_response_handler.cpp
@@ -68,7 +68,7 @@ void replication_response_handler(
   if (pending_key_request_map.find(key) != pending_key_request_map.end()) {
     bool succeed;
     unsigned tier_id = 1;
-    ServerThreadSet threads = {};
+    ServerThreadList threads = {};
 
     while (threads.size() == 0 && tier_id < kMaxTier) {
       threads = kHashRingUtil->get_responsible_threads(

--- a/kvs/tests/mock/mock_utils.cpp
+++ b/kvs/tests/mock/mock_utils.cpp
@@ -26,15 +26,16 @@ int MockZmqUtil::poll(long timeout, std::vector<zmq::pollitem_t>* items) {
 
 // get all threads responsible for a key from the "node_type" tier
 // metadata flag = 0 means the key is  metadata; otherwise, it is  regular data
-ServerThreadSet MockHashRingUtil::get_responsible_threads(
+ServerThreadList MockHashRingUtil::get_responsible_threads(
     Address respond_address, const Key& key, bool metadata,
     std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
     std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
     std::unordered_map<Key, KeyInfo>& placement, SocketCache& pushers,
     const std::vector<unsigned>& tier_ids, bool& succeed, unsigned& seed) {
-  ServerThreadSet threads;
+  ServerThreadList threads;
   succeed = true;
 
-  threads.insert(ServerThread("127.0.0.1", "127.0.0.1", 0));
+  //threads.insert(ServerThread("127.0.0.1", "127.0.0.1", 0));
+  threads.push_back(ServerThread("127.0.0.1", "127.0.0.1", 0));
   return threads;
 }

--- a/kvs/tests/mock/mock_utils.cpp
+++ b/kvs/tests/mock/mock_utils.cpp
@@ -35,7 +35,6 @@ ServerThreadList MockHashRingUtil::get_responsible_threads(
   ServerThreadList threads;
   succeed = true;
 
-  //threads.insert(ServerThread("127.0.0.1", "127.0.0.1", 0));
   threads.push_back(ServerThread("127.0.0.1", "127.0.0.1", 0));
   return threads;
 }

--- a/kvs/tests/mock/mock_utils.hpp
+++ b/kvs/tests/mock/mock_utils.hpp
@@ -29,7 +29,7 @@ class MockZmqUtil : public ZmqUtilInterface {
 
 class MockHashRingUtil : public HashRingUtilInterface {
  public:
-  virtual ServerThreadSet get_responsible_threads(
+  virtual ServerThreadList get_responsible_threads(
       Address respond_address, const Key& key, bool metadata,
       std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
       std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,


### PR DESCRIPTION
The Hash Ring methods that previously returned `ServerThreadSet` objects now return `ServerThreadList` objects. The files in `src/kvs`, `src/monitor` and `src/route` have been modified to work correctly with this change. In particular, `node_join_handler` has been modified so the first node gossips lost data back to a rejoining node.