### PR TITLE
Fixes EBS path read bug

### DIFF
--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -41,8 +41,6 @@ else
   PUBLIC_IP=$PRIVATE_IP
 fi
 
-
-
 echo -e "threads:" > conf/kvs-config.yml
 echo -e "    memory: 4" >> conf/kvs-config.yml
 echo -e "    ebs: 4" >> conf/kvs-config.yml
@@ -54,6 +52,8 @@ echo -e "    memory: 1" >> conf/kvs-config.yml
 echo -e "    ebs: 0" >> conf/kvs-config.yml
 echo -e "    minimum: 1" >> conf/kvs-config.yml
 echo -e "    local: 1" >> conf/kvs-config.yml
+
+echo -e "ebs: /ebs" >> conf/kvs-config.yml
 
 if [ "$1" = "mn" ]; then
   echo -e "monitoring:" >> conf/kvs-config.yml

--- a/kvs/include/utils/server_utils.hpp
+++ b/kvs/include/utils/server_utils.hpp
@@ -73,7 +73,7 @@ class EBSSerializer : public Serializer {
 
  public:
   EBSSerializer(unsigned& tid) : tid_(tid) {
-    YAML::Node conf = YAML::LoadFile("conf/config.yml");
+    YAML::Node conf = YAML::LoadFile("conf/kvs-config.yml");
 
     ebs_root_ = conf["ebs"].as<std::string>();
 


### PR DESCRIPTION
Configurable EBS path was being read from the wrong path, which was causing EBS nodes to crash loop. 