### PR TITLE
Changes server to exit after depart

### DIFF
--- a/kvs/src/kvs/self_depart_handler.cpp
+++ b/kvs/src/kvs/self_depart_handler.cpp
@@ -41,8 +41,7 @@ void self_depart_handler(
       }
     }
 
-    msg = "depart:" + std::to_string(kSelfTierId) + ":" + public_ip + ":" +
-          private_ip;
+    msg = "depart:" + msg;
 
     // notify all routing nodes
     for (const std::string& address : routing_address) {
@@ -84,6 +83,7 @@ void self_depart_handler(
       logger->error("Missing key replication factor in node depart routine");
     }
   }
+
 
   send_gossip(addr_keyset_map, pushers, serializer);
   kZmqUtil->send_string(

--- a/kvs/src/kvs/self_depart_handler.cpp
+++ b/kvs/src/kvs/self_depart_handler.cpp
@@ -84,7 +84,6 @@ void self_depart_handler(
     }
   }
 
-
   send_gossip(addr_keyset_map, pushers, serializer);
   kZmqUtil->send_string(
       public_ip + "_" + private_ip + "_" + std::to_string(kSelfTierId),

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -267,19 +267,13 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
     }
 
     if (pollitems[2].revents & ZMQ_POLLIN) {
-      auto work_start = std::chrono::system_clock::now();
-
       std::string serialized = kZmqUtil->recv_string(&self_depart_puller);
       self_depart_handler(thread_id, seed, public_ip, private_ip, logger,
                           serialized, global_hash_ring_map, local_hash_ring_map,
                           key_size_map, placement, routing_addresses,
                           monitoring_addresses, wt, pushers, serializer);
 
-      auto time_elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
-                              std::chrono::system_clock::now() - work_start)
-                              .count();
-      working_time += time_elapsed;
-      working_time_map[2] += time_elapsed;
+      return 0;
     }
 
     if (pollitems[3].revents & ZMQ_POLLIN) {

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -273,7 +273,7 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
                           key_size_map, placement, routing_addresses,
                           monitoring_addresses, wt, pushers, serializer);
 
-      return 0;
+      return;
     }
 
     if (pollitems[3].revents & ZMQ_POLLIN) {
@@ -646,4 +646,11 @@ int main(int argc, char* argv[]) {
 
   run(0, public_ip, private_ip, seed_ip, routing_addresses,
       monitoring_addresses, mgmt_ip);
+
+  // join on all threads to make sure they finish before exiting
+  for (unsigned tid = 1; tid < kThreadNum; tid++) {
+    worker_threads[tid].join();
+  }
+
+  return 0;
 }


### PR DESCRIPTION
Previously, when we received a self depart message, we kept running even after executing the depart logic. Threads now `return 0;` once they finish the `self_depart_handler` routine.