### PR TITLE
Speed up Travis build by pulling prebuilt images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ output*
 
 # ignore standard Mac OS X files/dirs
 .DS_Store
+default.profaw
 
 ################################################################################
 # vim

--- a/scripts/travis/docker-build.sh
+++ b/scripts/travis/docker-build.sh
@@ -17,6 +17,9 @@
 # only build a new Docker image if this is a master branch build -- ignore this
 # for PR builds
 if [[ "$TRAVIS_BRANCH" = "master" ]]; then
+  docker pull fluentproject/annakvs
+  docker pull fluentproject/kops
+
   cd dockerfiles
   docker build . -f anna.dockerfile -t fluentproject/annakvs
   docker build . -f kops.dockerfile -t fluentproject/kops


### PR DESCRIPTION
This should fix the timeout issue that's causing builds to fail currently.