### PR TITLE
Making lattice type optional

### DIFF
--- a/include/proto/requests.proto
+++ b/include/proto/requests.proto
@@ -36,7 +36,7 @@ message SetValue {
 
 message KeyTuple {
   required string key = 1;
-  required LatticeType lattice_type = 2;
+  optional LatticeType lattice_type = 2 [default = NO];
   optional uint32 error = 3;
   optional bytes payload = 4;
   optional uint32 address_cache_size = 5;

--- a/kvs/src/benchmark/benchmark.cpp
+++ b/kvs/src/benchmark/benchmark.cpp
@@ -134,7 +134,6 @@ void handle_request(
   rid += 1;
   KeyTuple* tp = req.add_tuples();
   tp->set_key(key);
-  tp->set_lattice_type(LatticeType::LWW);
   tp->set_address_cache_size(key_address_cache[key].size());
 
   if (value == "") {
@@ -147,6 +146,7 @@ void handle_request(
                     std::chrono::system_clock::now().time_since_epoch())
                     .count();
     auto ts = generate_timestamp(time, 0);
+    tp->set_lattice_type(LatticeType::LWW);
     tp->set_payload(serialize(ts, value));
   }
 

--- a/kvs/src/client/cpp/user.cpp
+++ b/kvs/src/client/cpp/user.cpp
@@ -107,7 +107,6 @@ void handle_request(
 
   KeyTuple* tp = req.add_tuples();
   tp->set_key(key);
-  tp->set_lattice_type(LatticeType::LWW);
   tp->set_address_cache_size(key_address_cache[key].size());
 
   if (value == "") {
@@ -120,6 +119,7 @@ void handle_request(
                     std::chrono::system_clock::now().time_since_epoch())
                     .count();
     auto ts = generate_timestamp(time, 0);
+    tp->set_lattice_type(LatticeType::LWW);
     tp->set_payload(serialize(ts, value));
   }
 

--- a/kvs/src/kvs/gossip_handler.cpp
+++ b/kvs/src/kvs/gossip_handler.cpp
@@ -44,7 +44,7 @@ void gossip_handler(
       if (std::find(threads.begin(), threads.end(), wt) !=
           threads.end()) {  // this means this worker thread is one of the
                             // responsible threads
-        if (key_stat_map[key].second != LatticeType::NO &&
+        if (key_stat_map.find(key) != key_stat_map.end() &&
             key_stat_map[key].second != tuple.lattice_type()) {
           logger->error("Lattice type mismatch: {} from query but {} expected.",
                         LatticeType_Name(tuple.lattice_type()),

--- a/kvs/tests/kvs/server_handler_base.hpp
+++ b/kvs/tests/kvs/server_handler_base.hpp
@@ -87,8 +87,7 @@ class ServerHandlerTest : public ::testing::Test {
 
   // NOTE: Pass in an empty string to avoid putting something into the
   // serializer
-  std::string get_key_request(Key key, LatticeType lattice_type,
-                              std::string ip) {
+  std::string get_key_request(Key key, std::string ip) {
     KeyRequest request;
     request.set_type(get_request_type("GET"));
     request.set_response_address(
@@ -97,7 +96,6 @@ class ServerHandlerTest : public ::testing::Test {
 
     KeyTuple* tp = request.add_tuples();
     tp->set_key(std::move(key));
-    tp->set_lattice_type(std::move(lattice_type));
 
     std::string request_str;
     request.SerializeToString(&request_str);

--- a/kvs/tests/kvs/test_user_request_handler.hpp
+++ b/kvs/tests/kvs/test_user_request_handler.hpp
@@ -20,7 +20,7 @@ TEST_F(ServerHandlerTest, UserGetLWWTest) {
   serializers[LatticeType::LWW]->put(key, serialize(0, value));
   key_stat_map[key].second = LatticeType::LWW;
 
-  std::string get_request = get_key_request(key, LatticeType::LWW, ip);
+  std::string get_request = get_key_request(key, ip);
 
   unsigned total_access = 0;
   unsigned seed = 0;
@@ -62,7 +62,7 @@ TEST_F(ServerHandlerTest, UserGetSetTest) {
                                      serialize(SetLattice<std::string>(s)));
   key_stat_map[key].second = LatticeType::SET;
 
-  std::string get_request = get_key_request(key, LatticeType::SET, ip);
+  std::string get_request = get_key_request(key, ip);
 
   unsigned total_access = 0;
   unsigned seed = 0;
@@ -128,7 +128,7 @@ TEST_F(ServerHandlerTest, UserPutAndGetLWWTest) {
   EXPECT_EQ(total_access, 1);
   EXPECT_EQ(key_access_timestamp[key].size(), 1);
 
-  std::string get_request = get_key_request(key, LatticeType::LWW, ip);
+  std::string get_request = get_key_request(key, ip);
 
   user_request_handler(total_access, seed, get_request, logger,
                        global_hash_ring_map, local_hash_ring_map, key_stat_map,
@@ -191,7 +191,7 @@ TEST_F(ServerHandlerTest, UserPutAndGetSetTest) {
   EXPECT_EQ(total_access, 1);
   EXPECT_EQ(key_access_timestamp[key].size(), 1);
 
-  std::string get_request = get_key_request(key, LatticeType::SET, ip);
+  std::string get_request = get_key_request(key, ip);
 
   user_request_handler(total_access, seed, get_request, logger,
                        global_hash_ring_map, local_hash_ring_map, key_stat_map,


### PR DESCRIPTION
made `lattice_type` optional with NO being the default.
when receiving a GET, the server no longer relies on the tuple's `lattice_type` to pick which kvs to look for the key. Instead, it relies on the `key_stat_map`.