### PR TITLE
Fixes Travis build

### DIFF
--- a/scripts/travis/travis-install.sh
+++ b/scripts/travis/travis-install.sh
@@ -34,7 +34,7 @@ install_protobuf() {
 }
 
 download_lcov() {
-  wget https://sourceforge.net/projects/ltp/files/Coverage%20Analysis/LCOV-1.13/lcov-1.13.tar.gz
+  wget http://sourceforge.net/projects/ltp/files/Coverage%20Analysis/LCOV-1.13/lcov-1.13.tar.gz
   tar xvzf lcov-${LCOV_VERSION}.tar.gz > /dev/null 2>&1
   rm -rf lcov-${LCOV_VERSION}.tar.gz
 }

--- a/scripts/travis/travis-install.sh
+++ b/scripts/travis/travis-install.sh
@@ -34,7 +34,7 @@ install_protobuf() {
 }
 
 download_lcov() {
-  wget http://downloads.sourceforge.net/ltp/lcov-${LCOV_VERSION}.tar.gz
+  wget https://sourceforge.net/projects/ltp/files/Coverage%20Analysis/LCOV-1.13/lcov-1.13.tar.gz
   tar xvzf lcov-${LCOV_VERSION}.tar.gz > /dev/null 2>&1
   rm -rf lcov-${LCOV_VERSION}.tar.gz
 }


### PR DESCRIPTION
Travis build depended on an `lcov` download path that was outdated. This PR fixes that.