### PR TITLE
KVS server now requests cache IPs from kops server.

### DIFF
--- a/functions/cache/src/cache.cpp
+++ b/functions/cache/src/cache.cpp
@@ -194,8 +194,7 @@ void run(KvsClient& client, Address ip, unsigned thread_id) {
           switch (key_type_map[key]) {
             case LatticeType::LWW: local_lww_cache.erase(key); break;
             case LatticeType::SET: local_set_cache.erase(key); break;
-            default:
-              break;  // this can never happen
+            default: break;  // this can never happen
           }
 
           key_type_map[key] = tuple.lattice_type();
@@ -220,8 +219,7 @@ void run(KvsClient& client, Address ip, unsigned thread_id) {
 
             local_set_cache[key] = new_val;
           }
-          default:
-            break;  // this should never happen!
+          default: break;  // this should never happen!
         }
       }
     }

--- a/k8s/kops_server.py
+++ b/k8s/kops_server.py
@@ -121,7 +121,7 @@ def run():
             msg = func_nodes_socket.recv_string()
 
             ks = KeySet()
-            for ip in util.get_pod_ips(clinet, 'role=function'):
+            for ip in util.get_pod_ips(client, 'role=function'):
                 ks.add_keys(ip)
 
             func_nodes_socket.send_string(ks.SerializeToString())

--- a/kvs/include/kvs_threads.hpp
+++ b/kvs/include/kvs_threads.hpp
@@ -41,6 +41,9 @@ const unsigned kMonitoringResponsePort = 6650;
 const unsigned kDepartDonePort = 6700;
 const unsigned kLatencyReportPort = 6750;
 
+// KVS nodes contact the kops server on this node
+const unsigned kKopsFuncNodesPort = 7002;
+
 class ServerThread {
   Address public_ip_;
   Address public_base_;
@@ -279,6 +282,10 @@ class BenchmarkThread {
 
 inline string get_join_count_req_address(string management_ip) {
   return "tcp://" + management_ip + ":" + std::to_string(kKopsRestartCountPort);
+}
+
+inline string get_func_nodes_req_address(string management_ip) {
+  return "tcp://" + management_ip + ":" + std::to_string(kKopsFuncNodesPort);
 }
 
 struct ThreadHash {

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -97,6 +97,12 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
 
   map<Key, KeyMetadata> metadata_map;
 
+  // ZMQ socket for asking kops server for IP addrs of functional nodes.
+  zmq::socket_t func_nodes_requester(context, ZMQ_REQ);
+  func_nodes_requester.setsockopt(ZMQ_SNDTIMEO, 1000);  // 1s
+  func_nodes_requester.setsockopt(ZMQ_RCVTIMEO, 1000);  // 1s
+  func_nodes_requester.connect(get_func_nodes_req_address(management_ip));
+
   // request server addresses from the seed node
   zmq::socket_t addr_requester(context, ZMQ_REQ);
   addr_requester.connect(RoutingThread(seed_ip, 0).seed_connect_address());
@@ -587,12 +593,6 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
 
       // Get the most recent list of cache IPs.
       // (Actually gets the list of all current functional nodes.)
-
-      zmq::socket_t func_nodes_requester(context, ZMQ_REQ);
-      func_nodes_requester.setsockopt(ZMQ_SNDTIMEO, 1000);  // 1s
-      func_nodes_requester.setsockopt(ZMQ_RCVTIMEO, 1000);  // 1s
-      func_nodes_requester.connect(get_func_nodes_req_address(management_ip));
-      // Send the request.
       // (The message content doesn't matter here; it's an argless RPC call.)
       kZmqUtil->send_string(" ", &func_nodes_requester);
       // Get the response.

--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -589,8 +589,8 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
       // (Actually gets the list of all current functional nodes.)
 
       zmq::socket_t func_nodes_requester(context, ZMQ_REQ);
-      func_nodes_requester.setsockopt(ZMQ_SNDTIMEO, 1000); // 1s
-      func_nodes_requester.setsockopt(ZMQ_RCVTIMEO, 1000); // 1s
+      func_nodes_requester.setsockopt(ZMQ_SNDTIMEO, 1000);  // 1s
+      func_nodes_requester.setsockopt(ZMQ_RCVTIMEO, 1000);  // 1s
       func_nodes_requester.connect(get_func_nodes_req_address(management_ip));
       // Send the request.
       // (The message content doesn't matter here; it's an argless RPC call.)
@@ -608,7 +608,8 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
       }
 
       // Process deleted caches
-      // (cache IPs that we were tracking but were not in the newest list of caches).
+      // (cache IPs that we were tracking but were not in the newest list of
+      // caches).
       for (const auto& cache_ip : deleted_caches) {
         cache_ip_to_keys.erase(cache_ip);
         for (auto& key_and_caches : key_to_cache_ips) {


### PR DESCRIPTION
KVS server will now request fresh cache IPs synchronously from kops server in the stats reporting interval. This happens immediately before sending out the requests for cached keys per cache IP.