### PR TITLE
Fixing metadata key parsing.

### DIFF
--- a/functions/cache/src/cache.cpp
+++ b/functions/cache/src/cache.cpp
@@ -194,8 +194,7 @@ void run(KvsClient& client, Address ip, unsigned thread_id) {
           switch (key_type_map[key]) {
             case LatticeType::LWW: local_lww_cache.erase(key); break;
             case LatticeType::SET: local_set_cache.erase(key); break;
-            default:
-              break;  // this can never happen
+            default: break;  // this can never happen
           }
 
           key_type_map[key] = tuple.lattice_type();
@@ -220,8 +219,7 @@ void run(KvsClient& client, Address ip, unsigned thread_id) {
 
             local_set_cache[key] = new_val;
           }
-          default:
-            break;  // this should never happen!
+          default: break;  // this should never happen!
         }
       }
     }

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -62,8 +62,8 @@ inline unsigned long long generate_timestamp(const unsigned& id) {
 // TODO: There should probably be a less silent error check.
 inline Key get_user_metadata_key(string data_key, UserMetadataType type) {
   if (type == UserMetadataType::cache_ip) {
-    return kMetadataIdentifier + kMetadataDelimiter +
-           kMetadataTypeCacheIP + kMetadataDelimiter + data_key;
+    return kMetadataIdentifier + kMetadataDelimiter + kMetadataTypeCacheIP +
+           kMetadataDelimiter + data_key;
   }
   return "";
 }

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -30,6 +30,7 @@ enum UserMetadataType { cache_ip };
 const string kMetadataIdentifier = "ANNA_METADATA";
 const string kMetadataDelimiter = "|";
 const char kMetadataDelimiterChar = '|';
+const string kMetadataTypeCacheIP = "cache_ip";
 
 inline void split(const string& s, char delim, vector<string>& elems) {
   std::stringstream ss(s);
@@ -61,8 +62,8 @@ inline unsigned long long generate_timestamp(const unsigned& id) {
 // TODO: There should probably be a less silent error check.
 inline Key get_user_metadata_key(string data_key, UserMetadataType type) {
   if (type == UserMetadataType::cache_ip) {
-    return kMetadataIdentifier + kMetadataDelimiter + data_key +
-           kMetadataDelimiter + "cache_ip";
+    return kMetadataIdentifier + kMetadataDelimiter +
+           kMetadataTypeCacheIP + kMetadataDelimiter + data_key;
   }
   return "";
 }
@@ -70,12 +71,15 @@ inline Key get_user_metadata_key(string data_key, UserMetadataType type) {
 // Inverse of get_user_metadata_key, returning just the key itself.
 // TODO: same problem as get_user_metadata_key with the metadata types.
 inline Key get_key_from_user_metadata(Key metadata_key) {
-  vector<string> tokens;
-  split(metadata_key, '|', tokens);
-
-  string metadata_type = tokens[tokens.size() - 1];
-  if (metadata_type == "cache_ip") {
-    return tokens[1];
+  string::size_type n_id;
+  string::size_type n_type;
+  // Find the first delimiter; this skips over the metadata identifier.
+  n_id = metadata_key.find(kMetadataDelimiter);
+  // Find the second delimiter; this skips over the metadata type.
+  n_type = metadata_key.find(kMetadataDelimiter, n_id + 1);
+  string metadata_type = metadata_key.substr(n_id + 1, n_type);
+  if (metadata_type == kMetadataTypeCacheIP) {
+    return metadata_key.substr(n_type + 1);
   }
 
   return "";

--- a/kvs/include/metadata.hpp
+++ b/kvs/include/metadata.hpp
@@ -80,11 +80,10 @@ inline Key get_metadata_key(const ServerThread& st, unsigned tier_id,
                   // MetadataType::replication
   }
 
-  return kMetadataIdentifier  + kMetadataDelimiter + metadata_type +
+  return kMetadataIdentifier + kMetadataDelimiter + metadata_type +
          kMetadataDelimiter + st.public_ip() + kMetadataDelimiter +
-         st.private_ip() + kMetadataDelimiter +
-         std::to_string(thread_num) + kMetadataDelimiter +
-         std::to_string(tier_id);
+         st.private_ip() + kMetadataDelimiter + std::to_string(thread_num) +
+         kMetadataDelimiter + std::to_string(tier_id);
 }
 
 // This version of the function should only be called with
@@ -94,14 +93,15 @@ inline Key get_metadata_key(const ServerThread& st, unsigned tier_id,
 // TODO: There should probably be a less silent error check.
 inline Key get_metadata_key(string data_key, MetadataType type) {
   if (type == MetadataType::replication) {
-    return kMetadataIdentifier + kMetadataDelimiter +
-           kMetadataTypeReplication + kMetadataDelimiter + data_key;
+    return kMetadataIdentifier + kMetadataDelimiter + kMetadataTypeReplication +
+           kMetadataDelimiter + data_key;
   }
   return "";
 }
 
 // Inverse of get_metadata_key, returning just the key itself.
-// Precondition: metadata_key is actually a metadata key (output of get_metadata_key).
+// Precondition: metadata_key is actually a metadata key (output of
+// get_metadata_key).
 // TODO: same problem as get_metadata_key with the metadata types.
 inline Key get_key_from_metadata(Key metadata_key) {
   string::size_type n_id;

--- a/kvs/include/metadata.hpp
+++ b/kvs/include/metadata.hpp
@@ -17,6 +17,8 @@
 
 #include "threads.hpp"
 
+const string kMetadataTypeReplication = "replication";
+
 // represents the replication state for each key
 struct KeyMetadata {
   map<TierId, unsigned> global_replication_;
@@ -67,21 +69,22 @@ enum MetadataType { replication, server_stats, key_access, key_size };
 
 inline Key get_metadata_key(const ServerThread& st, unsigned tier_id,
                             unsigned thread_num, MetadataType type) {
-  string suffix;
+  string metadata_type;
 
   switch (type) {
-    case MetadataType::server_stats: suffix = "stats"; break;
-    case MetadataType::key_access: suffix = "access"; break;
-    case MetadataType::key_size: suffix = "size"; break;
+    case MetadataType::server_stats: metadata_type = "stats"; break;
+    case MetadataType::key_access: metadata_type = "access"; break;
+    case MetadataType::key_size: metadata_type = "size"; break;
     default:
       return "";  // this should never happen; see note below about
                   // MetadataType::replication
   }
 
-  return kMetadataIdentifier + kMetadataDelimiter + st.public_ip() +
-         kMetadataDelimiter + st.private_ip() + kMetadataDelimiter +
+  return kMetadataIdentifier  + kMetadataDelimiter + metadata_type +
+         kMetadataDelimiter + st.public_ip() + kMetadataDelimiter +
+         st.private_ip() + kMetadataDelimiter +
          std::to_string(thread_num) + kMetadataDelimiter +
-         std::to_string(tier_id) + kMetadataDelimiter + suffix;
+         std::to_string(tier_id);
 }
 
 // This version of the function should only be called with
@@ -91,26 +94,31 @@ inline Key get_metadata_key(const ServerThread& st, unsigned tier_id,
 // TODO: There should probably be a less silent error check.
 inline Key get_metadata_key(string data_key, MetadataType type) {
   if (type == MetadataType::replication) {
-    return kMetadataIdentifier + kMetadataDelimiter + data_key +
-           kMetadataDelimiter + "replication";
+    return kMetadataIdentifier + kMetadataDelimiter +
+           kMetadataTypeReplication + kMetadataDelimiter + data_key;
   }
   return "";
 }
 
 // Inverse of get_metadata_key, returning just the key itself.
+// Precondition: metadata_key is actually a metadata key (output of get_metadata_key).
 // TODO: same problem as get_metadata_key with the metadata types.
 inline Key get_key_from_metadata(Key metadata_key) {
-  vector<string> tokens;
-  split(metadata_key, '|', tokens);
-
-  string metadata_type = tokens[tokens.size() - 1];
-  if (metadata_type == "replication") {
-    return tokens[1];
+  string::size_type n_id;
+  string::size_type n_type;
+  // Find the first delimiter; this skips over the metadata identifier.
+  n_id = metadata_key.find(kMetadataDelimiter);
+  // Find the second delimiter; this skips over the metadata type.
+  n_type = metadata_key.find(kMetadataDelimiter, n_id + 1);
+  string metadata_type = metadata_key.substr(n_id + 1, n_type);
+  if (metadata_type == kMetadataTypeReplication) {
+    return metadata_key.substr(n_type + 1);
   }
 
   return "";
 }
 
+// Precondition: key is from the non-data-key version of get_metadata_key.
 inline vector<string> split_metadata_key(Key key) {
   vector<string> tokens;
   split(key, kMetadataDelimiterChar, tokens);

--- a/kvs/src/monitor/stats_helpers.cpp
+++ b/kvs/src/monitor/stats_helpers.cpp
@@ -63,10 +63,10 @@ void collect_internal_stats(
         if (tuple.error() == 0) {
           vector<string> tokens = split_metadata_key(tuple.key());
 
-          Address ip_pair = tokens[1] + "/" + tokens[2];
-          unsigned tid = stoi(tokens[3]);
-          unsigned tier_id = stoi(tokens[4]);
-          string metadata_type = tokens[5];
+          string metadata_type = tokens[1];
+          Address ip_pair = tokens[2] + "/" + tokens[3];
+          unsigned tid = stoi(tokens[4]);
+          unsigned tier_id = stoi(tokens[5]);
 
           LWWValue lww_value;
           lww_value.ParseFromString(tuple.payload());


### PR DESCRIPTION
Previously,
- Both user and kvs metadata keys looked like ANNA_METADATA|...|\<metadata key type\>
- and it would look between the first and second delimiter for the key.
- If you nester a user and a kvs metadata key, you got ANNA_METADATA|ANNA_METADATA|...|\<type\>|\<type\>
- and it would parse out the user key incorrectly as ANNA_METADATA.

Now,
- Key metadata is a prefix only; metadata keys look like ANNA_METADATA|\<metadata key type\>|...
- and we look after the second delimiter for the key.
- Nesting (and indeed, arbitrary characters in user keys) should work just fine.