### PR TITLE
Adding OrderedSetLattice to async cache, as well as more tests.

### DIFF
--- a/kvs/src/kvs/server.cpp
+++ b/kvs/src/kvs/server.cpp
@@ -215,6 +215,7 @@ void run(unsigned thread_id, Address public_ip, Address private_ip,
 
   serializers[LatticeType::LWW] = lww_serializer;
   serializers[LatticeType::SET] = set_serializer;
+  serializers[LatticeType::ORDERED_SET] = ordered_set_serializer;
   serializers[LatticeType::CAUSAL] = causal_serializer;
   serializers[LatticeType::CROSSCAUSAL] = cross_causal_serializer;
 

--- a/kvs/tests/kvs/server_handler_base.hpp
+++ b/kvs/tests/kvs/server_handler_base.hpp
@@ -43,9 +43,11 @@ class ServerHandlerTest : public ::testing::Test {
   SerializerMap serializers;
   Serializer* lww_serializer;
   Serializer* set_serializer;
+  Serializer* ordered_set_serializer;
   Serializer* causal_serializer;
   MemoryLWWKVS* lww_kvs;
   MemorySetKVS* set_kvs;
+  MemoryOrderedSetKVS* ordered_set_kvs;
   MemoryCausalKVS* causal_kvs;
 
   ServerHandlerTest() {
@@ -57,6 +59,7 @@ class ServerHandlerTest : public ::testing::Test {
     causal_serializer = new MemoryCausalSerializer(causal_kvs);
     serializers[LatticeType::LWW] = lww_serializer;
     serializers[LatticeType::SET] = set_serializer;
+    serializers[LatticeType::ORDERED_SET] = ordered_set_serializer;
     serializers[LatticeType::CAUSAL] = causal_serializer;
 
     wt = ServerThread(ip, ip, thread_id);
@@ -66,8 +69,10 @@ class ServerHandlerTest : public ::testing::Test {
   virtual ~ServerHandlerTest() {
     delete lww_kvs;
     delete set_kvs;
+    delete ordered_set_serializer;
     delete serializers[LatticeType::LWW];
     delete serializers[LatticeType::SET];
+    delete serializers[LatticeType::ORDERED_SET];
   }
 
  public:

--- a/kvs/tests/kvs/test_user_request_handler.hpp
+++ b/kvs/tests/kvs/test_user_request_handler.hpp
@@ -93,6 +93,48 @@ TEST_F(ServerHandlerTest, UserGetSetTest) {
   EXPECT_EQ(key_access_tracker[key].size(), 1);
 }
 
+TEST_F(ServerHandlerTest, UserGetOrderedSetTest) {
+  Key key = "key";
+  ordered_set<string> s;
+  s.emplace("value1");
+  s.emplace("value2");
+  s.emplace("value3");
+  serializers[LatticeType::ORDERED_SET]->put(
+      key, serialize(OrderedSetLattice<string>(s)));
+  stored_key_map[key].type_ = LatticeType::ORDERED_SET;
+
+  string get_request = get_key_request(key, ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  user_request_handler(access_count, seed, get_request, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  vector<string> messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 1);
+
+  KeyResponse response;
+  response.ParseFromString(messages[0]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  KeyTuple rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.payload(), serialize(OrderedSetLattice<string>(s)));
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 0);
+  EXPECT_EQ(access_count, 1);
+  EXPECT_EQ(key_access_tracker[key].size(), 1);
+}
+
 TEST_F(ServerHandlerTest, UserGetCausalTest) {
   Key key = "key";
   VectorClockValuePair<SetLattice<string>> p;
@@ -284,6 +326,69 @@ TEST_F(ServerHandlerTest, UserPutAndGetSetTest) {
 
   EXPECT_EQ(rtp.key(), key);
   EXPECT_EQ(rtp.payload(), serialize(SetLattice<string>(s)));
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 1);
+  EXPECT_EQ(access_count, 2);
+  EXPECT_EQ(key_access_tracker[key].size(), 2);
+}
+
+TEST_F(ServerHandlerTest, UserPutAndGetOrderedSetTest) {
+  Key key = "key";
+  ordered_set<string> s;
+  s.emplace("value1");
+  s.emplace("value2");
+  s.emplace("value3");
+  string put_request = put_key_request(
+      key, LatticeType::SET, serialize(OrderedSetLattice<string>(s)), ip);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  user_request_handler(access_count, seed, put_request, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  vector<string> messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 1);
+
+  KeyResponse response;
+  response.ParseFromString(messages[0]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  KeyTuple rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 1);
+  EXPECT_EQ(access_count, 1);
+  EXPECT_EQ(key_access_tracker[key].size(), 1);
+
+  string get_request = get_key_request(key, ip);
+
+  user_request_handler(access_count, seed, get_request, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 2);
+
+  response.ParseFromString(messages[1]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.payload(), serialize(OrderedSetLattice<string>(s)));
   EXPECT_EQ(rtp.error(), 0);
 
   EXPECT_EQ(local_changeset.size(), 1);


### PR DESCRIPTION
OrderedSetLattice was implemented before async cache existed. 
The async cache implementation did not implement ordered set lattices. 
This patch fixes that, and also adds more tests.